### PR TITLE
[Feat] 멀티 모듈 구조 및 bootstrap 실행 환경 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.gradle
+.idea
+build
+out
+
+docker-compose.yml
+
+README.md
+HELP.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+
+FROM eclipse-temurin:21-jdk-jammy AS builder
+WORKDIR /workspace
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY quiz-api/build.gradle ./quiz-api/
+COPY quiz-application/build.gradle ./quiz-application/
+COPY quiz-bootstrap/build.gradle ./quiz-bootstrap/
+COPY quiz-domain/build.gradle ./quiz-domain/
+COPY quiz-infrastructure/build.gradle ./quiz-infrastructure/
+
+RUN chmod +x gradlew
+
+COPY quiz-api ./quiz-api
+COPY quiz-application ./quiz-application
+COPY quiz-bootstrap ./quiz-bootstrap
+COPY quiz-domain ./quiz-domain
+COPY quiz-infrastructure ./quiz-infrastructure
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :quiz-bootstrap:bootJar --no-daemon && \
+    cp quiz-bootstrap/build/libs/teamsky.jar app.jar
+
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+
+RUN useradd --system --create-home --uid 1001 spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'org.springframework.boot' version '3.3.0' apply false
+    id 'io.spring.dependency-management' version '1.1.5' apply false
+}
+
+group = 'com.project'
+version = '0.0.1-SNAPSHOT'
+
+ext {
+    springdocVersion = '2.6.0'
+}
+
+subprojects {
+    apply plugin: 'java-library'
+    apply plugin: 'io.spring.dependency-management'
+
+    group = rootProject.group
+    version = rootProject.version
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom "org.springframework.boot:spring-boot-dependencies:3.3.0"
+        }
+    }
+
+    dependencies {
+        compileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
+
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
+}

--- a/quiz-api/build.gradle
+++ b/quiz-api/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':quiz-application')
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${rootProject.springdocVersion}"
+}

--- a/quiz-application/build.gradle
+++ b/quiz-application/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':quiz-domain')
+
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework:spring-tx'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+}

--- a/quiz-bootstrap/build.gradle
+++ b/quiz-bootstrap/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'org.springframework.boot'
+}
+
+dependencies {
+    implementation project(':quiz-api')
+    implementation project(':quiz-infrastructure')
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    testImplementation project(':quiz-domain')
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testRuntimeOnly 'com.h2database:h2'
+}
+
+bootJar {
+    archiveFileName = 'teamsky.jar'
+}
+
+jar {
+    enabled = false
+}

--- a/quiz-bootstrap/src/main/java/com/project/quiz/QuizBootstrapApplication.java
+++ b/quiz-bootstrap/src/main/java/com/project/quiz/QuizBootstrapApplication.java
@@ -1,0 +1,12 @@
+package com.project.quiz;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = "com.project")
+public class QuizBootstrapApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(QuizBootstrapApplication.class, args);
+    }
+}

--- a/quiz-bootstrap/src/main/resources/application.yaml
+++ b/quiz-bootstrap/src/main/resources/application.yaml
@@ -1,0 +1,47 @@
+spring:
+  application:
+    name: teamsky
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/teamsky_db?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true}
+    username: ${SPRING_DATASOURCE_USERNAME:teamsky_user}
+    password: ${SPRING_DATASOURCE_PASSWORD:teamsky_password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+    show-sql: true
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+      password: ${SPRING_DATA_REDIS_PASSWORD:redis123}
+      timeout: 3s
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
+springdoc:
+  default-consume-media-type: application/json
+  default-produce-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+  api-docs:
+    path: /api-docs
+  show-actuator: true

--- a/quiz-domain/build.gradle
+++ b/quiz-domain/build.gradle
@@ -1,0 +1,2 @@
+dependencies {
+}

--- a/quiz-infrastructure/build.gradle
+++ b/quiz-infrastructure/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    implementation project(':quiz-domain')
+    implementation project(':quiz-application')
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    testImplementation 'com.h2database:h2'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,7 @@
+rootProject.name = 'teamsky'
+
+include 'quiz-api'
+include 'quiz-application'
+include 'quiz-domain'
+include 'quiz-infrastructure'
+include 'quiz-bootstrap'


### PR DESCRIPTION
## 요약
- 프로젝트를 멀티 모듈 구조로 재구성했습니다.
- Spring Boot 실행 진입점을 `quiz-bootstrap`으로 분리했습니다.
- 공통 Gradle 설정과 모듈별 책임을 정리했습니다.

## 변경 사항
- `settings.gradle`에 5개 모듈 구성 추가
- 루트 `build.gradle` 공통 설정 정리
- `quiz-bootstrap`에 실행 클래스 및 `application.yaml` 추가
- Dockerfile을 bootstrap 빌드 기준으로 수정

## 설계 의도
- 실행/조립은 bootstrap
- HTTP 입출력은 api
- 유스케이스는 application
- 도메인 모델은 domain
- 영속성은 infrastructure
로 분리해 요구사항의 멀티 모듈 설계를 설명 가능하게 만들었습니다.

## 검증
실행한 명령:
```bash
./gradlew :quiz-bootstrap:bootRun
docker compose up --build

## 영향 범위

- 루트 Gradle 설정
- bootstrap 실행 경로
- Docker 빌드/실행 구조

## 비고

도메인 유스케이스 구현은 후속 PR에서 진행합니다.