### PR TITLE
[Feat] 단원별 랜덤 문제 조회 API 구현

### DIFF
--- a/quiz-api/src/main/java/com/project/quiz/api/common/ErrorResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.project.quiz.api.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "API 오류 응답")
+public record ErrorResponse(
+        @Schema(description = "애플리케이션 오류 코드", example = "CHAPTER_NOT_FOUND")
+        String code,
+        @Schema(description = "오류 메시지", example = "Chapter not found. chapterId=1")
+        String message
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.project.quiz.api.common;
+
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ChapterNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleChapterNotFound(ChapterNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("CHAPTER_NOT_FOUND", exception.getMessage()));
+    }
+
+    @ExceptionHandler(NoAvailableProblemException.class)
+    public ResponseEntity<ErrorResponse> handleNoAvailableProblem(NoAvailableProblemException exception) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("NO_AVAILABLE_PROBLEM", exception.getMessage()));
+    }
+
+    @ExceptionHandler(ProblemNotFoundInChapterException.class)
+    public ResponseEntity<ErrorResponse> handleProblemNotFoundInChapter(ProblemNotFoundInChapterException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("PROBLEM_NOT_FOUND_IN_CHAPTER", exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getFieldErrors().stream()
+                .map(this::formatFieldError)
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse("INVALID_REQUEST", message));
+    }
+
+    private String formatFieldError(FieldError fieldError) {
+        return fieldError.getField() + ": " + fieldError.getDefaultMessage();
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemController.java
@@ -1,0 +1,68 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.application.solving.port.in.GetRandomProblemCommand;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemUseCase;
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "단원별 문제 풀이", description = "단원별 랜덤 문제 조회와 풀이 관련 엔드포인트")
+@RestController
+@RequestMapping("/api/problems")
+@RequiredArgsConstructor
+public class GetRandomProblemController {
+
+    private final GetRandomProblemUseCase getRandomProblemUseCase;
+
+    @Operation(
+            summary = "랜덤 미풀이 문제 조회",
+            description = "선택한 단원에서 이미 푼 문제와 직전에 건너뛴 문제를 제외하고 랜덤 문제 1개를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "랜덤 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 단원을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "해당 단원에 더 이상 출제 가능한 문제가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/random")
+    public ResponseEntity<GetRandomProblemResponse> getRandomProblem(
+            @Valid @RequestBody GetRandomProblemRequest request
+    ) {
+        GetRandomProblemResult result = getRandomProblemUseCase.getRandomProblem(
+                new GetRandomProblemCommand(request.userId(), request.chapterId())
+        );
+
+        return ResponseEntity.ok(new GetRandomProblemResponse(
+                result.problemId(),
+                result.content(),
+                result.choices().stream()
+                        .map(choice -> choice.content())
+                        .toList(),
+                result.answerCorrectRate()
+        ));
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemRequest.java
@@ -1,0 +1,19 @@
+package com.project.quiz.api.solving;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "랜덤 문제 조회 요청")
+public record GetRandomProblemRequest(
+        @Schema(description = "단원 ID", example = "1")
+        @NotNull(message = "chapterId is required")
+        @Positive(message = "chapterId must be positive")
+        Long chapterId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/GetRandomProblemResponse.java
@@ -1,0 +1,22 @@
+package com.project.quiz.api.solving;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "랜덤 문제 조회 응답")
+public record GetRandomProblemResponse(
+        @Schema(description = "문제 ID", example = "1")
+        Long problemId,
+
+        @Schema(description = "문제 내용", example = "문제 설명")
+        String content,
+
+        @ArraySchema(schema = @Schema(description = "객관식 선택지 목록", example = "지문1"))
+        List<String> choices,
+
+        @Schema(description = "문제 정답률. 30명 미만이 풀었으면 null 입니다.", example = "67", nullable = true)
+        Integer answerCorrectRate
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ChapterNotFoundException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ChapterNotFoundException.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.exception;
+
+public class ChapterNotFoundException extends RuntimeException {
+
+    public ChapterNotFoundException(Long chapterId) {
+        super("Chapter not found. chapterId=" + chapterId);
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/NoAvailableProblemException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/NoAvailableProblemException.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.exception;
+
+public class NoAvailableProblemException extends RuntimeException {
+
+    public NoAvailableProblemException(Long userId, Long chapterId) {
+        super("No available problem for userId=%d, chapterId=%d".formatted(userId, chapterId));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemChoiceResult.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemChoiceResult.java
@@ -1,0 +1,4 @@
+package com.project.quiz.application.solving.port.in;
+
+public record GetRandomProblemChoiceResult(Integer sequence, String content) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemCommand.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemCommand.java
@@ -1,0 +1,4 @@
+package com.project.quiz.application.solving.port.in;
+
+public record GetRandomProblemCommand(Long userId, Long chapterId) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemResult.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemResult.java
@@ -1,0 +1,11 @@
+package com.project.quiz.application.solving.port.in;
+
+import java.util.List;
+
+public record GetRandomProblemResult(
+        Long problemId,
+        String content,
+        List<GetRandomProblemChoiceResult> choices,
+        Integer answerCorrectRate
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemUseCase.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/GetRandomProblemUseCase.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.in;
+
+public interface GetRandomProblemUseCase {
+
+    GetRandomProblemResult getRandomProblem(GetRandomProblemCommand command);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/CheckChapterExistsPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/CheckChapterExistsPort.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.out;
+
+public interface CheckChapterExistsPort {
+
+    boolean existsById(Long chapterId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadChapterProblemsPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadChapterProblemsPort.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.problem.Problem;
+
+import java.util.List;
+
+public interface LoadChapterProblemsPort {
+
+    List<Problem> loadByChapterId(Long chapterId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadProblemCorrectRatePort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadProblemCorrectRatePort.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+
+import java.util.Optional;
+
+public interface LoadProblemCorrectRatePort {
+
+    Optional<ProblemCorrectRateSummary> loadByProblemId(Long problemId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadUserChapterSolvingStatePort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadUserChapterSolvingStatePort.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.solving.UserChapterSolvingState;
+
+public interface LoadUserChapterSolvingStatePort {
+
+    UserChapterSolvingState load(Long userId, Long chapterId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/PickRandomProblemPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/PickRandomProblemPort.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.problem.Problem;
+
+import java.util.List;
+
+public interface PickRandomProblemPort {
+
+    Problem pick(List<Problem> problems);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetRandomProblemService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetRandomProblemService.java
@@ -1,0 +1,72 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.port.in.GetRandomProblemChoiceResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemCommand;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemUseCase;
+import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
+import com.project.quiz.application.solving.port.out.LoadChapterProblemsPort;
+import com.project.quiz.application.solving.port.out.LoadProblemCorrectRatePort;
+import com.project.quiz.application.solving.port.out.LoadUserChapterSolvingStatePort;
+import com.project.quiz.application.solving.port.out.PickRandomProblemPort;
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemChoice;
+import com.project.quiz.domain.solving.UserChapterSolvingState;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class GetRandomProblemService implements GetRandomProblemUseCase {
+
+    private final CheckChapterExistsPort checkChapterExistsPort;
+    private final LoadChapterProblemsPort loadChapterProblemsPort;
+    private final LoadUserChapterSolvingStatePort loadUserChapterSolvingStatePort;
+    private final LoadProblemCorrectRatePort loadProblemCorrectRatePort;
+    private final PickRandomProblemPort pickRandomProblemPort;
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+
+    @Override
+    public GetRandomProblemResult getRandomProblem(GetRandomProblemCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        if (!checkChapterExistsPort.existsById(command.chapterId())) {
+            throw new ChapterNotFoundException(command.chapterId());
+        }
+
+        UserChapterSolvingState solvingState =
+                loadUserChapterSolvingStatePort.load(command.userId(), command.chapterId());
+
+        List<Problem> selectableProblems = loadChapterProblemsPort.loadByChapterId(command.chapterId()).stream()
+                .filter(solvingState::isSelectable)
+                .toList();
+
+        if (selectableProblems.isEmpty()) {
+            throw new NoAvailableProblemException(command.userId(), command.chapterId());
+        }
+
+        Problem selectedProblem = pickRandomProblemPort.pick(selectableProblems);
+        Integer correctRate = loadProblemCorrectRatePort.loadByProblemId(selectedProblem.id())
+                .map(problemCorrectRatePolicy::calculateExposedRate)
+                .orElse(null);
+
+        return new GetRandomProblemResult(
+                selectedProblem.id(),
+                selectedProblem.content(),
+                selectedProblem.choices().stream()
+                        .map(this::toChoiceResult)
+                        .toList(),
+                correctRate
+        );
+    }
+
+    private GetRandomProblemChoiceResult toChoiceResult(ProblemChoice choice) {
+        return new GetRandomProblemChoiceResult(choice.sequence(), choice.content());
+    }
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/Problem.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/Problem.java
@@ -1,0 +1,16 @@
+package com.project.quiz.domain.problem;
+
+import java.util.List;
+
+public record Problem(
+        Long id,
+        Long chapterId,
+        String content,
+        ProblemType type,
+        List<ProblemChoice> choices
+) {
+
+    public boolean belongsTo(Long targetChapterId) {
+        return chapterId.equals(targetChapterId);
+    }
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemChoice.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemChoice.java
@@ -1,0 +1,7 @@
+package com.project.quiz.domain.problem;
+
+public record ProblemChoice(
+        Integer sequence,
+        String content
+) {
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemType.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemType.java
@@ -1,0 +1,6 @@
+package com.project.quiz.domain.problem;
+
+public enum ProblemType {
+    SINGLE_ANSWER,
+    MULTIPLE_ANSWER
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/solving/UserChapterSolvingState.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/solving/UserChapterSolvingState.java
@@ -1,0 +1,27 @@
+package com.project.quiz.domain.solving;
+
+import com.project.quiz.domain.problem.Problem;
+
+import java.util.Set;
+
+public record UserChapterSolvingState(
+        Long userId,
+        Long chapterId,
+        Set<Long> solvedProblemIds,
+        Long lastSkippedProblemId
+) {
+
+    public boolean isSelectable(Problem problem) {
+        return problem.belongsTo(chapterId)
+                && !isSolved(problem.id())
+                && !isLastSkipped(problem.id());
+    }
+
+    public boolean isSolved(Long problemId) {
+        return solvedProblemIds.contains(problemId);
+    }
+
+    public boolean isLastSkipped(Long problemId) {
+        return lastSkippedProblemId != null && lastSkippedProblemId.equals(problemId);
+    }
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRatePolicy.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRatePolicy.java
@@ -1,0 +1,15 @@
+package com.project.quiz.domain.statistics;
+
+public final class ProblemCorrectRatePolicy {
+
+    private static final long MINIMUM_SOLVED_USER_COUNT = 30L;
+
+    public Integer calculateExposedRate(ProblemCorrectRateSummary summary) {
+        if (summary.solvedUserCount() < MINIMUM_SOLVED_USER_COUNT) {
+            return null;
+        }
+
+        double rate = ((double) summary.correctUserCount() / summary.solvedUserCount()) * 100;
+        return (int) Math.round(rate);
+    }
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRateSummary.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRateSummary.java
@@ -1,0 +1,7 @@
+package com.project.quiz.domain.statistics;
+
+public record ProblemCorrectRateSummary(
+        long solvedUserCount,
+        long correctUserCount
+) {
+}


### PR DESCRIPTION
## 요약
- 랜덤 문제 조회 유스케이스와 API를 구현했습니다.
- validation, 예외 처리, Swagger 문서화를 함께 반영했습니다.

## 변경 사항
- domain 모델 추가
- `GetRandomProblemUseCase` 및 service 구현
- 랜덤 문제 조회 controller / DTO 추가
- 전역 예외 핸들러 및 Swagger 문서화 추가

## 설계 의도
랜덤 문제 조회는 API에서 직접 처리하지 않고 application service를 통해 수행하도록 분리했습니다.
도메인 규칙은 `Problem`, `UserChapterSolvingState`, `ProblemCorrectRatePolicy`에 반영했습니다.

## 검증
실행한 명령:
```bash
./gradlew :quiz-application:test
./gradlew :quiz-api:test

## 영향 범위

- quiz-domain
- quiz-application
- quiz-api
