### PR TITLE
[Feat] JPA 영속성 계층 및 Docker Compose 시드 데이터 구성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: teamsky-app
+    ports:
+      - "${APP_PORT:-8080}:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-teamsky_db}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:-teamsky_user}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-teamsky_password}
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_DATA_REDIS_PASSWORD: ${REDIS_PASSWORD:-redis123}
+      TZ: Asia/Seoul
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - teamsky-network
+
+  mysql:
+    image: mysql:8.0
+    container_name: teamsky-mysql
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-teamsky_db}
+      MYSQL_USER: ${MYSQL_USER:-teamsky_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-teamsky_password}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d:ro
+    restart: unless-stopped
+    networks:
+      - teamsky-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD:-root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+  redis:
+    image: redis:7-alpine
+    container_name: teamsky-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:-redis123}
+      --appendonly yes
+      --save 900 1
+      --save 300 10
+      --save 60 10000
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+    networks:
+      - teamsky-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis123}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+volumes:
+  mysql-data:
+  redis-data:
+
+networks:
+  teamsky-network:
+    driver: bridge

--- a/docker/mysql/init/01-schema-and-seed.sql
+++ b/docker/mysql/init/01-schema-and-seed.sql
@@ -1,0 +1,142 @@
+SET NAMES utf8mb4;
+SET character_set_client = utf8mb4;
+SET character_set_connection = utf8mb4;
+SET character_set_results = utf8mb4;
+
+CREATE TABLE IF NOT EXISTS chapters (
+    id BIGINT NOT NULL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS problems (
+    id BIGINT NOT NULL PRIMARY KEY,
+    chapter_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    problem_type VARCHAR(30) NOT NULL,
+    CONSTRAINT fk_problems_chapter FOREIGN KEY (chapter_id) REFERENCES chapters (id)
+);
+
+CREATE TABLE IF NOT EXISTS problem_choices (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    problem_id BIGINT NOT NULL,
+    sequence INT NOT NULL,
+    content TEXT NOT NULL,
+    CONSTRAINT fk_problem_choices_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
+);
+
+CREATE TABLE IF NOT EXISTS solve_attempts (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    chapter_id BIGINT NOT NULL,
+    problem_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    is_correct BIT NULL,
+    created_at DATETIME NOT NULL,
+    INDEX idx_solve_attempts_user_chapter (user_id, chapter_id),
+    INDEX idx_solve_attempts_problem (problem_id),
+    INDEX idx_solve_attempts_user_chapter_status (user_id, chapter_id, status),
+    CONSTRAINT fk_solve_attempts_chapter FOREIGN KEY (chapter_id) REFERENCES chapters (id),
+    CONSTRAINT fk_solve_attempts_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
+);
+
+INSERT INTO chapters (id, title) VALUES
+    (1, 'Java Basics'),
+    (2, 'Spring Core')
+ON DUPLICATE KEY UPDATE title = VALUES(title);
+
+INSERT INTO problems (id, chapter_id, content, problem_type) VALUES
+    (1001, 1, 'Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.', 'SINGLE_ANSWER'),
+    (1002, 1, 'JVM 메모리 영역에 대한 설명으로 옳은 것을 모두 고르세요.', 'MULTIPLE_ANSWER'),
+    (1003, 1, 'List와 Set의 차이로 가장 적절한 것을 고르세요.', 'SINGLE_ANSWER'),
+    (1004, 1, '예외 처리 방식으로 적절한 것을 모두 고르세요.', 'MULTIPLE_ANSWER'),
+    (2001, 2, 'Spring Bean의 기본 scope는 무엇인가요?', 'SINGLE_ANSWER'),
+    (2002, 2, '트랜잭션 전파 속성에 대한 설명으로 옳은 것을 모두 고르세요.', 'MULTIPLE_ANSWER')
+ON DUPLICATE KEY UPDATE
+    chapter_id = VALUES(chapter_id),
+    content = VALUES(content),
+    problem_type = VALUES(problem_type);
+
+INSERT INTO problem_choices (problem_id, sequence, content) VALUES
+    (1001, 1, 'int'),
+    (1001, 2, 'long'),
+    (1001, 3, 'boolean'),
+    (1001, 4, 'short'),
+    (1001, 5, 'byte'),
+
+    (1002, 1, 'Heap은 객체 인스턴스가 저장되는 영역이다.'),
+    (1002, 2, 'Method Area는 클래스 메타데이터를 저장한다.'),
+    (1002, 3, 'Stack은 모든 스레드가 공유한다.'),
+    (1002, 4, 'PC Register는 스레드마다 하나씩 존재한다.'),
+    (1002, 5, 'Native Method Stack은 JVM과 무관하다.'),
+
+    (1003, 1, 'List는 순서를 보장하고 Set은 중복을 허용한다.'),
+    (1003, 2, 'List는 중복을 허용하고 Set은 순서를 보장하지 않을 수 있다.'),
+    (1003, 3, '둘 다 중복을 허용하지 않는다.'),
+    (1003, 4, '둘 다 인덱스로 접근할 수 있다.'),
+    (1003, 5, 'Set은 항상 정렬된다.'),
+
+    (1004, 1, '복구 가능한 예외는 적절한 계층에서 처리하는 것이 좋다.'),
+    (1004, 2, '모든 예외는 무조건 catch 후 무시해야 한다.'),
+    (1004, 3, '의미 없는 try-catch 재포장은 피하는 편이 좋다.'),
+    (1004, 4, '검증 실패는 일관된 응답 포맷으로 반환하는 것이 좋다.'),
+    (1004, 5, '예외 메시지는 항상 내부 스택트레이스를 그대로 노출해야 한다.'),
+
+    (2001, 1, 'prototype'),
+    (2001, 2, 'singleton'),
+    (2001, 3, 'request'),
+    (2001, 4, 'session'),
+    (2001, 5, 'application'),
+
+    (2002, 1, 'REQUIRED는 기존 트랜잭션이 있으면 참여한다.'),
+    (2002, 2, 'REQUIRES_NEW는 항상 새 트랜잭션을 시작한다.'),
+    (2002, 3, 'MANDATORY는 트랜잭션이 없어도 새로 만든다.'),
+    (2002, 4, 'SUPPORTS는 트랜잭션이 없어도 실행 가능하다.'),
+    (2002, 5, 'NEVER는 트랜잭션 안에서 실행되어야 한다.')
+ON DUPLICATE KEY UPDATE
+    sequence = VALUES(sequence),
+    content = VALUES(content);
+
+INSERT INTO solve_attempts (user_id, chapter_id, problem_id, status, is_correct, created_at) VALUES
+    (1, 1, 1003, 'SOLVED', b'1', '2026-03-26 10:00:00'),
+    (1, 1, 1002, 'SKIPPED', NULL, '2026-03-26 10:05:00'),
+    (2, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:00:00'),
+    (3, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:01:00'),
+    (4, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:02:00'),
+    (5, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:03:00'),
+    (6, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:04:00'),
+    (7, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:05:00'),
+    (8, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:06:00'),
+    (9, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:07:00'),
+    (10, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:08:00'),
+    (11, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:09:00'),
+    (12, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:10:00'),
+    (13, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:11:00'),
+    (14, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:12:00'),
+    (15, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:13:00'),
+    (16, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:14:00'),
+    (17, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:15:00'),
+    (18, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:16:00'),
+    (19, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:17:00'),
+    (20, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:18:00'),
+    (21, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:19:00'),
+    (22, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:20:00'),
+    (23, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:21:00'),
+    (24, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:22:00'),
+    (25, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:23:00'),
+    (26, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:24:00'),
+    (27, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:25:00'),
+    (28, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:26:00'),
+    (29, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:27:00'),
+    (30, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:28:00'),
+    (31, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:29:00'),
+    (32, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:30:00'),
+    (2, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:00:00'),
+    (3, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:01:00'),
+    (4, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:02:00'),
+    (5, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:03:00'),
+    (6, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:04:00'),
+    (7, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:05:00'),
+    (8, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:06:00'),
+    (9, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:07:00'),
+    (10, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:08:00'),
+    (11, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:09:00');

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/AttemptStatus.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/AttemptStatus.java
@@ -1,0 +1,6 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+public enum AttemptStatus {
+    SOLVED,
+    SKIPPED
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ChapterJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ChapterJpaEntity.java
@@ -1,0 +1,35 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "chapters")
+public class ChapterJpaEntity {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    protected ChapterJpaEntity() {
+    }
+
+    public static ChapterJpaEntity create(Long id, String title) {
+        ChapterJpaEntity entity = new ChapterJpaEntity();
+        entity.id = id;
+        entity.title = title;
+        return entity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemChoiceJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemChoiceJpaEntity.java
@@ -1,0 +1,49 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "problem_choices")
+public class ProblemChoiceJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    protected ProblemChoiceJpaEntity() {
+    }
+
+    public static ProblemChoiceJpaEntity create(Long problemId, Integer sequence, String content) {
+        ProblemChoiceJpaEntity entity = new ProblemChoiceJpaEntity();
+        entity.problemId = problemId;
+        entity.sequence = sequence;
+        entity.content = content;
+        return entity;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemJpaEntity.java
@@ -1,0 +1,55 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import com.project.quiz.domain.problem.ProblemType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "problems")
+public class ProblemJpaEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "chapter_id", nullable = false)
+    private Long chapterId;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "problem_type", nullable = false, length = 30)
+    private ProblemType type;
+
+    protected ProblemJpaEntity() {
+    }
+
+    public static ProblemJpaEntity create(Long id, Long chapterId, String content, ProblemType type) {
+        ProblemJpaEntity entity = new ProblemJpaEntity();
+        entity.id = id;
+        entity.chapterId = chapterId;
+        entity.content = content;
+        entity.type = type;
+        return entity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getChapterId() {
+        return chapterId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public ProblemType getType() {
+        return type;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptJpaEntity.java
@@ -1,0 +1,65 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "solve_attempts")
+public class SolveAttemptJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "chapter_id", nullable = false)
+    private Long chapterId;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AttemptStatus status;
+
+    @Column(name = "is_correct")
+    private Boolean correct;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    protected SolveAttemptJpaEntity() {
+    }
+
+    public static SolveAttemptJpaEntity create(
+            Long userId,
+            Long chapterId,
+            Long problemId,
+            AttemptStatus status,
+            Boolean correct,
+            LocalDateTime createdAt
+    ) {
+        SolveAttemptJpaEntity entity = new SolveAttemptJpaEntity();
+        entity.userId = userId;
+        entity.chapterId = chapterId;
+        entity.problemId = problemId;
+        entity.status = status;
+        entity.correct = correct;
+        entity.createdAt = createdAt;
+        return entity;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/mapper/ProblemMapper.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/mapper/ProblemMapper.java
@@ -1,0 +1,25 @@
+package com.project.quiz.infrastructure.persistence.mapper;
+
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemChoice;
+import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ProblemMapper {
+
+    public Problem toDomain(ProblemJpaEntity entity, List<ProblemChoiceJpaEntity> choices) {
+        return new Problem(
+                entity.getId(),
+                entity.getChapterId(),
+                entity.getContent(),
+                entity.getType(),
+                choices.stream()
+                        .map(choice -> new ProblemChoice(choice.getSequence(), choice.getContent()))
+                        .toList()
+        );
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ChapterJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ChapterJpaRepository.java
@@ -1,0 +1,7 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ChapterJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChapterJpaRepository extends JpaRepository<ChapterJpaEntity, Long> {
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemChoiceJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemChoiceJpaRepository.java
@@ -1,0 +1,11 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemChoiceJpaRepository extends JpaRepository<ProblemChoiceJpaEntity, Long> {
+
+    List<ProblemChoiceJpaEntity> findAllByProblemIdInOrderByProblemIdAscSequenceAsc(List<Long> problemIds);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemCorrectRateProjection.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemCorrectRateProjection.java
@@ -1,0 +1,8 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+public interface ProblemCorrectRateProjection {
+
+    long getSolvedUserCount();
+
+    long getCorrectUserCount();
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemJpaRepository.java
@@ -1,0 +1,14 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProblemJpaRepository extends JpaRepository<ProblemJpaEntity, Long> {
+
+    List<ProblemJpaEntity> findAllByChapterIdOrderByIdAsc(@Param("chapterId") Long chapterId);
+
+    boolean existsByIdAndChapterId(Long id, Long chapterId);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptJpaRepository.java
@@ -1,0 +1,38 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SolveAttemptJpaRepository extends JpaRepository<SolveAttemptJpaEntity, Long> {
+
+    @Query("""
+            select sa.problemId
+            from SolveAttemptJpaEntity sa
+            where sa.userId = :userId
+              and sa.chapterId = :chapterId
+              and sa.status = com.project.quiz.infrastructure.persistence.entity.AttemptStatus.SOLVED
+            """)
+    List<Long> findSolvedProblemIds(@Param("userId") Long userId, @Param("chapterId") Long chapterId);
+
+    Optional<SolveAttemptJpaEntity> findTopByUserIdAndChapterIdAndStatusOrderByIdDesc(
+            Long userId,
+            Long chapterId,
+            AttemptStatus status
+    );
+
+    @Query("""
+            select
+                count(distinct sa.userId) as solvedUserCount,
+                count(distinct case when sa.correct = true then sa.userId end) as correctUserCount
+            from SolveAttemptJpaEntity sa
+            where sa.problemId = :problemId
+              and sa.status = com.project.quiz.infrastructure.persistence.entity.AttemptStatus.SOLVED
+            """)
+    Optional<ProblemCorrectRateProjection> findCorrectRateSummaryByProblemId(@Param("problemId") Long problemId);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapter.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapter.java
@@ -1,0 +1,113 @@
+package com.project.quiz.infrastructure.solving;
+
+import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
+import com.project.quiz.application.solving.port.out.CheckProblemInChapterPort;
+import com.project.quiz.application.solving.port.out.LoadChapterProblemsPort;
+import com.project.quiz.application.solving.port.out.LoadProblemCorrectRatePort;
+import com.project.quiz.application.solving.port.out.LoadUserChapterSolvingStatePort;
+import com.project.quiz.application.solving.port.out.SaveSkippedProblemPort;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.solving.UserChapterSolvingState;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
+import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
+import com.project.quiz.infrastructure.persistence.mapper.ProblemMapper;
+import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RandomProblemPersistenceAdapter implements
+        CheckChapterExistsPort,
+        CheckProblemInChapterPort,
+        LoadChapterProblemsPort,
+        LoadUserChapterSolvingStatePort,
+        LoadProblemCorrectRatePort,
+        SaveSkippedProblemPort {
+
+    private final ChapterJpaRepository chapterJpaRepository;
+    private final ProblemJpaRepository problemJpaRepository;
+    private final ProblemChoiceJpaRepository problemChoiceJpaRepository;
+    private final SolveAttemptJpaRepository solveAttemptJpaRepository;
+    private final ProblemMapper problemMapper;
+
+    @Override
+    public boolean existsById(Long chapterId) {
+        return chapterJpaRepository.existsById(chapterId);
+    }
+
+    @Override
+    public boolean existsByIdAndChapterId(Long problemId, Long chapterId) {
+        return problemJpaRepository.existsByIdAndChapterId(problemId, chapterId);
+    }
+
+    @Override
+    public List<Problem> loadByChapterId(Long chapterId) {
+        List<com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity> problems =
+                problemJpaRepository.findAllByChapterIdOrderByIdAsc(chapterId);
+
+        List<Long> problemIds = problems.stream()
+                .map(problem -> problem.getId())
+                .toList();
+
+        Map<Long, List<ProblemChoiceJpaEntity>> choicesByProblemId = problemChoiceJpaRepository
+                .findAllByProblemIdInOrderByProblemIdAscSequenceAsc(problemIds)
+                .stream()
+                .collect(Collectors.groupingBy(ProblemChoiceJpaEntity::getProblemId));
+
+        return problems.stream()
+                .map(problem -> problemMapper.toDomain(
+                        problem,
+                        choicesByProblemId.getOrDefault(problem.getId(), List.of())
+                ))
+                .toList();
+    }
+
+    @Override
+    public UserChapterSolvingState load(Long userId, Long chapterId) {
+        List<Long> solvedProblemIds = solveAttemptJpaRepository.findSolvedProblemIds(userId, chapterId);
+        Long lastSkippedProblemId = solveAttemptJpaRepository
+                .findTopByUserIdAndChapterIdAndStatusOrderByIdDesc(userId, chapterId, AttemptStatus.SKIPPED)
+                .map(attempt -> attempt.getProblemId())
+                .orElse(null);
+
+        return new UserChapterSolvingState(userId, chapterId, new HashSet<>(solvedProblemIds), lastSkippedProblemId);
+    }
+
+    @Override
+    public Optional<ProblemCorrectRateSummary> loadByProblemId(Long problemId) {
+        return solveAttemptJpaRepository.findCorrectRateSummaryByProblemId(problemId)
+                .map(projection -> new ProblemCorrectRateSummary(
+                        projection.getSolvedUserCount(),
+                        projection.getCorrectUserCount()
+                ));
+    }
+
+    @Override
+    @Transactional
+    public void saveSkippedProblem(Long userId, Long chapterId, Long problemId) {
+        solveAttemptJpaRepository.save(
+                SolveAttemptJpaEntity.create(
+                        userId,
+                        chapterId,
+                        problemId,
+                        AttemptStatus.SKIPPED,
+                        null,
+                        java.time.LocalDateTime.now()
+                )
+        );
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPickerAdapter.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPickerAdapter.java
@@ -1,0 +1,18 @@
+package com.project.quiz.infrastructure.solving;
+
+import com.project.quiz.application.solving.port.out.PickRandomProblemPort;
+import com.project.quiz.domain.problem.Problem;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class RandomProblemPickerAdapter implements PickRandomProblemPort {
+
+    @Override
+    public Problem pick(List<Problem> problems) {
+        int index = ThreadLocalRandom.current().nextInt(problems.size());
+        return problems.get(index);
+    }
+}


### PR DESCRIPTION
## 요약
- 랜덤 문제 조회 유스케이스를 실제 JPA 영속성 계층과 연결했습니다.
- Docker Compose 실행 시 사용할 MySQL 시드 데이터를 구성했습니다.

## 변경 사항
- JPA entity / repository / adapter 구현
- FK id 기반 영속성 모델 적용
- problem / choice / solve_attempts 조회 쿼리 구현
- Docker Compose MySQL init SQL 추가

## 설계 의도
JPA 객체 연관관계를 최소화하고 FK id 기반 영속성 모델을 사용해
조회 의도를 명시적으로 드러내고 프록시/지연로딩 의존을 줄였습니다.

## 검증
실행한 명령:
```bash
./gradlew :quiz-infrastructure:test
docker compose down -v
docker compose up --build

## 영향 범위

- quiz-infrastructure
- docker-compose.yml
- MySQL 초기화 SQL
