### PR TITLE
[Feat] 문제 넘기기 API 구현

### DIFF
--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SkipProblemController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SkipProblemController.java
@@ -1,0 +1,64 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.SkipProblemCommand;
+import com.project.quiz.application.solving.port.in.SkipProblemUseCase;
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "단원별 문제 풀이", description = "단원별 랜덤 문제 조회와 풀이 관련 엔드포인트")
+@RestController
+@RequestMapping("/api/problems")
+@RequiredArgsConstructor
+public class SkipProblemController {
+
+    private final SkipProblemUseCase skipProblemUseCase;
+
+    @Operation(
+            summary = "문제 넘기기",
+            description = "현재 문제를 건너뛴 뒤 같은 단원에서 다음 랜덤 문제 1개를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문제를 건너뛰고 다음 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 단원 또는 문제가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "건너뛴 이후 더 이상 출제 가능한 문제가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/skip")
+    public ResponseEntity<GetRandomProblemResponse> skipProblem(@Valid @RequestBody SkipProblemRequest request) {
+        GetRandomProblemResult result = skipProblemUseCase.skipProblem(
+                new SkipProblemCommand(request.userId(), request.chapterId(), request.problemId())
+        );
+
+        return ResponseEntity.ok(new GetRandomProblemResponse(
+                result.problemId(),
+                result.content(),
+                result.choices().stream().map(choice -> choice.content()).toList(),
+                result.answerCorrectRate()
+        ));
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SkipProblemRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SkipProblemRequest.java
@@ -1,0 +1,24 @@
+package com.project.quiz.api.solving;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "문제 넘기기 요청")
+public record SkipProblemRequest(
+        @Schema(description = "단원 ID", example = "1")
+        @NotNull(message = "chapterId is required")
+        @Positive(message = "chapterId must be positive")
+        Long chapterId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId,
+
+        @Schema(description = "건너뛸 현재 문제 ID", example = "1001")
+        @NotNull(message = "problemId is required")
+        @Positive(message = "problemId must be positive")
+        Long problemId
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemNotFoundInChapterException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemNotFoundInChapterException.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.exception;
+
+public class ProblemNotFoundInChapterException extends RuntimeException {
+
+    public ProblemNotFoundInChapterException(Long chapterId, Long problemId) {
+        super("Problem not found in chapter. chapterId=%d, problemId=%d".formatted(chapterId, problemId));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SkipProblemCommand.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SkipProblemCommand.java
@@ -1,0 +1,4 @@
+package com.project.quiz.application.solving.port.in;
+
+public record SkipProblemCommand(Long userId, Long chapterId, Long problemId) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SkipProblemUseCase.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SkipProblemUseCase.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.in;
+
+public interface SkipProblemUseCase {
+
+    GetRandomProblemResult skipProblem(SkipProblemCommand command);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/CheckProblemInChapterPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/CheckProblemInChapterPort.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.out;
+
+public interface CheckProblemInChapterPort {
+
+    boolean existsByIdAndChapterId(Long problemId, Long chapterId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/SaveSkippedProblemPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/SaveSkippedProblemPort.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.out;
+
+public interface SaveSkippedProblemPort {
+
+    void saveSkippedProblem(Long userId, Long chapterId, Long problemId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/SkipProblemService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/SkipProblemService.java
@@ -1,0 +1,47 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.port.in.GetRandomProblemCommand;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemUseCase;
+import com.project.quiz.application.solving.port.in.SkipProblemCommand;
+import com.project.quiz.application.solving.port.in.SkipProblemUseCase;
+import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
+import com.project.quiz.application.solving.port.out.CheckProblemInChapterPort;
+import com.project.quiz.application.solving.port.out.SaveSkippedProblemPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class SkipProblemService implements SkipProblemUseCase {
+
+    private final CheckChapterExistsPort checkChapterExistsPort;
+    private final CheckProblemInChapterPort checkProblemInChapterPort;
+    private final SaveSkippedProblemPort saveSkippedProblemPort;
+    private final GetRandomProblemUseCase getRandomProblemUseCase;
+
+    @Override
+    @Transactional
+    public GetRandomProblemResult skipProblem(SkipProblemCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        if (!checkChapterExistsPort.existsById(command.chapterId())) {
+            throw new ChapterNotFoundException(command.chapterId());
+        }
+
+        if (!checkProblemInChapterPort.existsByIdAndChapterId(command.problemId(), command.chapterId())) {
+            throw new ProblemNotFoundInChapterException(command.chapterId(), command.problemId());
+        }
+
+        saveSkippedProblemPort.saveSkippedProblem(command.userId(), command.chapterId(), command.problemId());
+
+        return getRandomProblemUseCase.getRandomProblem(
+                new GetRandomProblemCommand(command.userId(), command.chapterId())
+        );
+    }
+}


### PR DESCRIPTION
## 요약
- 현재 문제를 skip 처리하고 다음 랜덤 문제를 반환하는 API를 구현했습니다.

## 변경 사항
- `SkipProblemUseCase` 및 service 구현
- skip 저장 port / adapter 추가
- problem-in-chapter 검증 추가
- `POST /api/problems/skip` controller / DTO / 예외 처리 추가

## 설계 의도
문제 넘기기는 단순 조회가 아니라 상태 저장 후 다음 문제 조회가 이어지는 복합 유스케이스이므로
application service에서 트랜잭션 경계를 가지고 처리하도록 구성했습니다.

## 검증
실행한 명령:
```bash
./gradlew :quiz-application:test
./gradlew :quiz-api:test
./gradlew :quiz-bootstrap:test

## 영향 범위

- quiz-application
- quiz-api
- quiz-infrastructure