### PR TITLE
[Test/Docs] 테스트 추가 및 README 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,329 @@
+# teamsky
+
+학습 플랫폼의 핵심 기능인 `단원별 문제 풀이`를 중심으로 구현한 Spring Boot 3.3 / Java 21 멀티 모듈 프로젝트입니다.
+
+현재 문서 기준 구현 범위는 아래 두 API입니다.
+
+- 랜덤 문제 조회
+- 문제 넘기기
+
+## 1. 프로젝트 목표
+
+이 프로젝트는 단순 CRUD보다 아래 관점을 더 중요하게 두고 구현했습니다.
+
+- 도메인 규칙을 계층 밖으로 새지 않게 유지
+- 멀티 모듈 구조로 책임을 명확히 분리
+- 테스트 가능한 구조 유지
+- 조회 성능을 고려한 설계
+- Docker Compose로 애플리케이션과 인프라를 한 번에 실행 가능하게 구성
+
+## 2. 멀티 모듈 구조
+
+```text
+root
+├── quiz-bootstrap
+├── quiz-api
+├── quiz-application
+├── quiz-domain
+└── quiz-infrastructure
+```
+
+### `quiz-bootstrap`
+
+실행 모듈입니다.
+
+- `@SpringBootApplication`
+- 실제 애플리케이션 조립
+- 테스트 시 end-to-end 검증 진입점
+
+### `quiz-api`
+
+HTTP 입출력 계층입니다.
+
+- controller
+- request/response DTO
+- validation
+- Swagger 문서화
+- exception -> HTTP 응답 변환
+
+### `quiz-application`
+
+유스케이스 계층입니다.
+
+- use case
+- command/result
+- port in/out
+- transaction boundary
+
+### `quiz-domain`
+
+순수 도메인 모델 계층입니다.
+
+- 문제
+- 선택지
+- 사용자-단원 풀이 상태
+- 정답률 정책
+
+### `quiz-infrastructure`
+
+영속성 및 외부 기술 구현 계층입니다.
+
+- JPA entity
+- Spring Data JPA repository
+- application port adapter
+- random picker 구현
+
+## 3. 왜 이렇게 나눴는가
+
+이 과제는 멀티 모듈과 DDD 원칙을 요구합니다. 따라서 실행, API, 유스케이스, 도메인, 영속성을 같은 모듈에 섞지 않고 분리했습니다.
+
+이 구조의 장점은 아래와 같습니다.
+
+- API 요구사항 변경이 도메인 모델에 직접 영향을 덜 줍니다.
+- 도메인 규칙을 Spring MVC/JPA 없이 단위 테스트할 수 있습니다.
+- 조회 성능 최적화가 필요할 때 `quiz-infrastructure`에서 집중적으로 개선할 수 있습니다.
+- `quiz-bootstrap`에서만 실행과 조립을 담당하므로 배포 단위가 명확합니다.
+
+## 4. DDD 관점 정리
+
+### Ubiquitous Language
+
+이 프로젝트에서는 아래 용어를 공통 언어로 정했습니다.
+
+- `Chapter`: 문제를 묶는 단원
+- `Problem`: 사용자가 푸는 문제
+- `Choice`: 객관식 선택지
+- `SolveAttempt`: 사용자의 풀이 또는 건너뛰기 기록
+- `SkippedProblem`: 사용자가 직전에 넘긴 문제
+- `CorrectRate`: 문제 정답률
+- `UserChapterSolvingState`: 특정 사용자-특정 단원 기준 풀이 상태
+
+### Bounded Context
+
+현재 기능 기준으로 도메인을 크게 세 개의 문맥으로 해석했습니다.
+
+- `problem`
+  - 문제와 선택지 자체
+- `solving`
+  - 사용자의 풀이 상태, 문제 넘기기, 출제 가능 여부
+- `statistics`
+  - 정답률 공개 정책
+
+프로젝트 규모상 별도 모듈로 더 쪼개지는 않았고, `quiz-domain` 내부 패키지로 경계를 표현했습니다.
+
+### Aggregate Root 관점
+
+현재 구현에서 핵심적으로 본 aggregate root 성격의 모델은 아래입니다.
+
+- `Problem`
+- `UserChapterSolvingState`
+
+특히 이 요구사항의 핵심 규칙은 `Chapter` 단독보다 `사용자 + chapter + 직전 skip + 이미 푼 문제` 조합에 가깝기 때문에, `UserChapterSolvingState`를 중요한 도메인 모델로 해석했습니다.
+
+## 5. API
+
+## 5.1 랜덤 문제 조회
+
+- `POST /api/problems/random`
+
+요청
+
+```json
+{
+  "chapterId": 1,
+  "userId": 1
+}
+```
+
+응답 예시
+
+```json
+{
+  "problemId": 1001,
+  "content": "Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.",
+  "choices": ["int", "long", "boolean", "short", "byte"],
+  "answerCorrectRate": 68
+}
+```
+
+동작 규칙
+
+- 이미 푼 문제 제외
+- 직전에 skip한 문제 제외
+- 남은 문제 중 랜덤 1개 반환
+- 30명 이상 풀이 시 정답률 공개
+- 30명 미만이면 `answerCorrectRate = null`
+
+오류 응답
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 chapter
+- `409`: 더 이상 출제 가능한 문제 없음
+
+## 5.2 문제 넘기기
+
+- `POST /api/problems/skip`
+
+요청
+
+```json
+{
+  "chapterId": 1,
+  "userId": 1,
+  "problemId": 1001
+}
+```
+
+응답
+
+- 현재 문제를 `SKIPPED`로 기록한 뒤
+- 같은 단원에서 다음 랜덤 문제 1개를 바로 반환
+
+오류 응답
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 chapter 또는 해당 chapter에 속하지 않는 problem
+- `409`: skip 이후 더 이상 출제 가능한 문제 없음
+
+## 6. 현재 구현된 핵심 규칙
+
+- 직전 skip 문제는 다음 랜덤 추출 대상에서 제외
+- solved 상태 문제는 랜덤 후보에서 제외
+- 문제 정답률은 `solve_attempts` 집계를 통해 계산
+- 정답률 공개 규칙은 `ProblemCorrectRatePolicy`가 담당
+
+## 7. JPA 설계 관점
+
+현재 JPA entity는 객체 연관관계를 최소화하고 FK id 기반으로 설계했습니다.
+
+예를 들면:
+
+- `ProblemJpaEntity`는 `ChapterJpaEntity`를 직접 참조하지 않고 `chapterId`만 가집니다.
+- `ProblemChoiceJpaEntity`도 `ProblemJpaEntity` 객체를 잡지 않고 `problemId`만 가집니다.
+
+이렇게 한 이유는 아래와 같습니다.
+
+- JPA 프록시와 지연 로딩 의존 최소화
+- aggregate 경계 명확화
+- 조회 쿼리 의도를 더 명시적으로 표현
+- `quiz-domain`과 `quiz-infrastructure` 분리 유지
+
+DB 레벨 FK 제약은 유지하지만, JPA 객체 그래프는 남용하지 않는 방향을 선택했습니다.
+
+## 8. 현재 동작하는 쿼리와 성능 관점
+
+현재 랜덤 문제 조회는 아래 순서로 동작합니다.
+
+1. chapter 존재 여부 확인
+2. chapter의 문제 목록 조회
+3. 문제 id 목록으로 선택지 일괄 조회
+4. 사용자 solved 문제 목록 조회
+5. 사용자의 마지막 skipped 문제 조회
+6. 특정 문제의 정답률 집계 조회
+
+현재 구조의 장점은 아래와 같습니다.
+
+- `Problem -> Choice`를 join fetch로 크게 끌고 오지 않고 명시 조회 후 조합합니다.
+- solved 문제 목록과 마지막 skipped 문제 조회가 분리되어 있어 의도가 명확합니다.
+- 정답률 집계는 `solve_attempts`에서 count/sum 집계로 처리합니다.
+
+현재 한계도 있습니다.
+
+- 랜덤 선택 전 chapter 내 문제를 모두 메모리로 가져와 필터링합니다.
+- 문제 수가 매우 많아지면 이 부분은 더 최적화가 필요합니다.
+- 지금은 과제 범위에 맞춰 읽기 쉬운 구조를 우선했습니다.
+
+향후 개선 여지는 아래와 같습니다.
+
+- DB에서 후보 문제를 더 직접적으로 줄이는 쿼리
+- `solve_attempts(user_id, chapter_id, status)` 인덱스 최적화
+- 정답률 집계 캐시 또는 별도 통계 테이블
+
+즉 현재 성능은 "과제 구현 단계에서는 합리적"이지만, 대규모 데이터 기준 최적화가 끝난 상태는 아닙니다.
+
+## 9. 테스트 전략
+
+현재 테스트는 계층별로 나눴습니다.
+
+- application unit test
+  - `GetRandomProblemServiceTest`
+  - `SkipProblemServiceTest`
+- api slice test
+  - `@WebMvcTest` 기반 controller 테스트
+- infrastructure integration test
+  - `RandomProblemPersistenceAdapterTest`
+- bootstrap end-to-end test
+  - `GetRandomProblemEndToEndTest`
+
+이 구조로 인해 규칙, HTTP 계약, JPA 매핑, 실제 계층 연결을 각각 분리해서 검증할 수 있습니다.
+
+## 10. Docker Compose 실행
+
+### 실행
+
+```bash
+docker compose up --build
+```
+
+실행 구성
+
+- `app`: Spring Boot 애플리케이션
+- `mysql`: 메인 DB
+- `redis`: 이후 사용자 시도 횟수/캐시 계층 확장용
+
+### 시드 데이터
+
+MySQL 컨테이너는 아래 디렉터리의 SQL을 초기화 시 실행합니다.
+
+- `docker/mysql/init/01-schema-and-seed.sql`
+
+이 SQL은 아래를 수행합니다.
+
+- 테이블 생성
+- 예제 chapter/problem/problem_choices/solve_attempts 삽입
+
+중요한 점:
+
+- 이 init SQL은 MySQL 볼륨이 처음 만들어질 때만 실행됩니다.
+- 이미 기존 볼륨이 있으면 새 데이터가 반영되지 않습니다.
+
+초기 데이터를 다시 넣으려면:
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
+## 11. 로컬 실행
+
+```bash
+./gradlew :quiz-bootstrap:bootRun
+```
+
+Swagger:
+
+- `http://localhost:8080/swagger-ui.html`
+
+헬스 체크:
+
+- `http://localhost:8080/api/health`
+- `http://localhost:8080/actuator/health`
+
+## 12. 주요 테스트 명령
+
+```bash
+./gradlew :quiz-application:test
+./gradlew :quiz-api:test
+./gradlew :quiz-infrastructure:test
+./gradlew :quiz-bootstrap:test
+```
+
+## 13. 현재 범위와 남은 작업
+
+현재 구현 범위:
+
+- 랜덤 문제 조회
+- 문제 넘기기
+- Swagger 문서화
+- Docker Compose 기반 실행
+- 계층별 테스트

--- a/quiz-api/src/test/java/com/project/quiz/api/TestApiApplication.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/TestApiApplication.java
@@ -1,0 +1,9 @@
+package com.project.quiz.api;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+public class TestApiApplication {
+}

--- a/quiz-api/src/test/java/com/project/quiz/api/solving/GetRandomProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/solving/GetRandomProblemControllerTest.java
@@ -1,0 +1,121 @@
+package com.project.quiz.api.solving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.application.solving.port.in.GetRandomProblemChoiceResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemUseCase;
+import com.project.quiz.api.common.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GetRandomProblemController.class)
+@ContextConfiguration(classes = {
+        com.project.quiz.api.TestApiApplication.class,
+        GetRandomProblemController.class,
+        GlobalExceptionHandler.class
+})
+class GetRandomProblemControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GetRandomProblemUseCase getRandomProblemUseCase;
+
+    @Test
+    @DisplayName("정상 요청이면 랜덤 문제를 반환한다")
+    void returnRandomProblem() throws Exception {
+        GetRandomProblemRequest request = new GetRandomProblemRequest(1L, 1L);
+        GetRandomProblemResult result = new GetRandomProblemResult(
+                100L,
+                "문제 설명",
+                List.of(
+                        new GetRandomProblemChoiceResult(1, "지문1"),
+                        new GetRandomProblemChoiceResult(2, "지문2"),
+                        new GetRandomProblemChoiceResult(3, "지문3"),
+                        new GetRandomProblemChoiceResult(4, "지문4"),
+                        new GetRandomProblemChoiceResult(5, "지문5")
+                ),
+                67
+        );
+
+        when(getRandomProblemUseCase.getRandomProblem(any())).thenReturn(result);
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(100))
+                .andExpect(jsonPath("$.content").value("문제 설명"))
+                .andExpect(jsonPath("$.choices[0]").value("지문1"))
+                .andExpect(jsonPath("$.choices[4]").value("지문5"))
+                .andExpect(jsonPath("$.answerCorrectRate").value(67));
+
+        verify(getRandomProblemUseCase).getRandomProblem(any());
+    }
+
+    @Test
+    @DisplayName("validation 실패면 400을 반환한다")
+    void returnBadRequestWhenValidationFails() throws Exception {
+        GetRandomProblemRequest request = new GetRandomProblemRequest(0L, null);
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").isString());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 챕터면 404를 반환한다")
+    void returnNotFoundWhenChapterDoesNotExist() throws Exception {
+        GetRandomProblemRequest request = new GetRandomProblemRequest(1L, 999L);
+
+        when(getRandomProblemUseCase.getRandomProblem(any()))
+                .thenThrow(new ChapterNotFoundException(999L));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CHAPTER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Chapter not found. chapterId=999"));
+    }
+
+    @Test
+    @DisplayName("출제 가능한 문제가 없으면 409를 반환한다")
+    void returnConflictWhenNoAvailableProblemExists() throws Exception {
+        GetRandomProblemRequest request = new GetRandomProblemRequest(1L, 1L);
+
+        when(getRandomProblemUseCase.getRandomProblem(any()))
+                .thenThrow(new NoAvailableProblemException(1L, 1L));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"))
+                .andExpect(jsonPath("$.message").value("No available problem for userId=1, chapterId=1"));
+    }
+}

--- a/quiz-api/src/test/java/com/project/quiz/api/solving/SkipProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/solving/SkipProblemControllerTest.java
@@ -1,0 +1,94 @@
+package com.project.quiz.api.solving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.SkipProblemUseCase;
+import com.project.quiz.api.TestApiApplication;
+import com.project.quiz.api.common.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SkipProblemController.class)
+@ContextConfiguration(classes = {
+        TestApiApplication.class,
+        SkipProblemController.class,
+        GlobalExceptionHandler.class
+})
+class SkipProblemControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SkipProblemUseCase skipProblemUseCase;
+
+    @Test
+    @DisplayName("정상 요청이면 건너뛴 뒤 다음 문제를 반환한다")
+    void returnNextRandomProblem() throws Exception {
+        when(skipProblemUseCase.skipProblem(any()))
+                .thenReturn(new GetRandomProblemResult(1002L, "다음 문제", List.of(), null));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 1001L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(1002))
+                .andExpect(jsonPath("$.content").value("다음 문제"));
+    }
+
+    @Test
+    @DisplayName("요청 검증 실패면 400을 반환한다")
+    void returnBadRequestWhenValidationFails() throws Exception {
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, null, 0L))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("문제가 단원에 없으면 404를 반환한다")
+    void returnNotFoundWhenProblemNotInChapter() throws Exception {
+        when(skipProblemUseCase.skipProblem(any()))
+                .thenThrow(new ProblemNotFoundInChapterException(1L, 1001L));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 1001L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+    }
+
+    @Test
+    @DisplayName("출제 가능한 문제가 없으면 409를 반환한다")
+    void returnConflictWhenNoAvailableProblemExists() throws Exception {
+        when(skipProblemUseCase.skipProblem(any()))
+                .thenThrow(new NoAvailableProblemException(1L, 1L));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 1001L))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"));
+    }
+}

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetRandomProblemServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetRandomProblemServiceTest.java
@@ -1,0 +1,153 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.port.in.GetRandomProblemCommand;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
+import com.project.quiz.application.solving.port.out.LoadChapterProblemsPort;
+import com.project.quiz.application.solving.port.out.LoadProblemCorrectRatePort;
+import com.project.quiz.application.solving.port.out.LoadUserChapterSolvingStatePort;
+import com.project.quiz.application.solving.port.out.PickRandomProblemPort;
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemChoice;
+import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.domain.solving.UserChapterSolvingState;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetRandomProblemServiceTest {
+
+    @Mock
+    private CheckChapterExistsPort checkChapterExistsPort;
+
+    @Mock
+    private LoadChapterProblemsPort loadChapterProblemsPort;
+
+    @Mock
+    private LoadUserChapterSolvingStatePort loadUserChapterSolvingStatePort;
+
+    @Mock
+    private LoadProblemCorrectRatePort loadProblemCorrectRatePort;
+
+    @Mock
+    private PickRandomProblemPort pickRandomProblemPort;
+
+    private GetRandomProblemService getRandomProblemService;
+
+    @BeforeEach
+    void setUp() {
+        getRandomProblemService = new GetRandomProblemService(
+                checkChapterExistsPort,
+                loadChapterProblemsPort,
+                loadUserChapterSolvingStatePort,
+                loadProblemCorrectRatePort,
+                pickRandomProblemPort
+        );
+    }
+
+    @Test
+    void chapterDoesNotExistThenThrowException() {
+        GetRandomProblemCommand command = new GetRandomProblemCommand(1L, 100L);
+
+        when(checkChapterExistsPort.existsById(100L)).thenReturn(false);
+
+        assertThatThrownBy(() -> getRandomProblemService.getRandomProblem(command))
+                .isInstanceOf(ChapterNotFoundException.class)
+                .hasMessageContaining("chapterId=100");
+    }
+
+    @Test
+    void returnRandomSelectableProblemAndRoundedCorrectRate() {
+        GetRandomProblemCommand command = new GetRandomProblemCommand(1L, 10L);
+        Problem solvedProblem = problem(101L, 10L, "solved");
+        Problem skippedProblem = problem(102L, 10L, "skipped");
+        Problem selectableProblem = problem(103L, 10L, "selectable");
+
+        when(checkChapterExistsPort.existsById(10L)).thenReturn(true);
+        when(loadUserChapterSolvingStatePort.load(1L, 10L))
+                .thenReturn(new UserChapterSolvingState(1L, 10L, Set.of(101L), 102L));
+        when(loadChapterProblemsPort.loadByChapterId(10L))
+                .thenReturn(List.of(solvedProblem, skippedProblem, selectableProblem));
+        when(pickRandomProblemPort.pick(anyList())).thenReturn(selectableProblem);
+        when(loadProblemCorrectRatePort.loadByProblemId(103L))
+                .thenReturn(Optional.of(new ProblemCorrectRateSummary(30L, 20L)));
+
+        GetRandomProblemResult result = getRandomProblemService.getRandomProblem(command);
+
+        assertThat(result.problemId()).isEqualTo(103L);
+        assertThat(result.content()).isEqualTo("selectable");
+        assertThat(result.answerCorrectRate()).isEqualTo(67);
+        assertThat(result.choices()).hasSize(5);
+        assertThat(result.choices().get(0).sequence()).isEqualTo(1);
+        verify(pickRandomProblemPort).pick(List.of(selectableProblem));
+    }
+
+    @Test
+    void whenAllProblemsAreUnavailableThenThrowException() {
+        GetRandomProblemCommand command = new GetRandomProblemCommand(1L, 10L);
+        Problem solvedProblem = problem(101L, 10L, "solved");
+        Problem skippedProblem = problem(102L, 10L, "skipped");
+
+        when(checkChapterExistsPort.existsById(10L)).thenReturn(true);
+        when(loadUserChapterSolvingStatePort.load(1L, 10L))
+                .thenReturn(new UserChapterSolvingState(1L, 10L, Set.of(101L), 102L));
+        when(loadChapterProblemsPort.loadByChapterId(10L))
+                .thenReturn(List.of(solvedProblem, skippedProblem));
+
+        assertThatThrownBy(() -> getRandomProblemService.getRandomProblem(command))
+                .isInstanceOf(NoAvailableProblemException.class)
+                .hasMessageContaining("userId=1")
+                .hasMessageContaining("chapterId=10");
+    }
+
+    @Test
+    void whenCorrectRateDoesNotMeetExposureConditionThenReturnNull() {
+        GetRandomProblemCommand command = new GetRandomProblemCommand(1L, 10L);
+        Problem selectableProblem = problem(103L, 10L, "selectable");
+
+        when(checkChapterExistsPort.existsById(10L)).thenReturn(true);
+        when(loadUserChapterSolvingStatePort.load(1L, 10L))
+                .thenReturn(new UserChapterSolvingState(1L, 10L, Set.of(), null));
+        when(loadChapterProblemsPort.loadByChapterId(10L))
+                .thenReturn(List.of(selectableProblem));
+        when(pickRandomProblemPort.pick(anyList())).thenReturn(selectableProblem);
+        when(loadProblemCorrectRatePort.loadByProblemId(103L))
+                .thenReturn(Optional.of(new ProblemCorrectRateSummary(29L, 29L)));
+
+        GetRandomProblemResult result = getRandomProblemService.getRandomProblem(command);
+
+        assertThat(result.answerCorrectRate()).isNull();
+    }
+
+    private Problem problem(Long problemId, Long chapterId, String content) {
+        return new Problem(
+                problemId,
+                chapterId,
+                content,
+                ProblemType.SINGLE_ANSWER,
+                List.of(
+                        new ProblemChoice(1, "choice-1"),
+                        new ProblemChoice(2, "choice-2"),
+                        new ProblemChoice(3, "choice-3"),
+                        new ProblemChoice(4, "choice-4"),
+                        new ProblemChoice(5, "choice-5")
+                )
+        );
+    }
+}

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/SkipProblemServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/SkipProblemServiceTest.java
@@ -1,0 +1,88 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.port.in.GetRandomProblemCommand;
+import com.project.quiz.application.solving.port.in.GetRandomProblemResult;
+import com.project.quiz.application.solving.port.in.GetRandomProblemUseCase;
+import com.project.quiz.application.solving.port.in.SkipProblemCommand;
+import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
+import com.project.quiz.application.solving.port.out.CheckProblemInChapterPort;
+import com.project.quiz.application.solving.port.out.SaveSkippedProblemPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SkipProblemServiceTest {
+
+    @Mock
+    private CheckChapterExistsPort checkChapterExistsPort;
+
+    @Mock
+    private CheckProblemInChapterPort checkProblemInChapterPort;
+
+    @Mock
+    private SaveSkippedProblemPort saveSkippedProblemPort;
+
+    @Mock
+    private GetRandomProblemUseCase getRandomProblemUseCase;
+
+    private SkipProblemService skipProblemService;
+
+    @BeforeEach
+    void setUp() {
+        skipProblemService = new SkipProblemService(
+                checkChapterExistsPort,
+                checkProblemInChapterPort,
+                saveSkippedProblemPort,
+                getRandomProblemUseCase
+        );
+    }
+
+    @Test
+    void chapterDoesNotExistThenThrowException() {
+        SkipProblemCommand command = new SkipProblemCommand(1L, 99L, 100L);
+
+        when(checkChapterExistsPort.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> skipProblemService.skipProblem(command))
+                .isInstanceOf(ChapterNotFoundException.class);
+    }
+
+    @Test
+    void problemDoesNotBelongToChapterThenThrowException() {
+        SkipProblemCommand command = new SkipProblemCommand(1L, 1L, 100L);
+
+        when(checkChapterExistsPort.existsById(1L)).thenReturn(true);
+        when(checkProblemInChapterPort.existsByIdAndChapterId(100L, 1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> skipProblemService.skipProblem(command))
+                .isInstanceOf(ProblemNotFoundInChapterException.class);
+    }
+
+    @Test
+    void saveSkipAndReturnNextRandomProblem() {
+        SkipProblemCommand command = new SkipProblemCommand(1L, 1L, 100L);
+        GetRandomProblemResult nextProblem = new GetRandomProblemResult(101L, "next", List.of(), null);
+
+        when(checkChapterExistsPort.existsById(1L)).thenReturn(true);
+        when(checkProblemInChapterPort.existsByIdAndChapterId(100L, 1L)).thenReturn(true);
+        when(getRandomProblemUseCase.getRandomProblem(new GetRandomProblemCommand(1L, 1L))).thenReturn(nextProblem);
+
+        GetRandomProblemResult result = skipProblemService.skipProblem(command);
+
+        verify(saveSkippedProblemPort).saveSkippedProblem(1L, 1L, 100L);
+        verify(getRandomProblemUseCase).getRandomProblem(new GetRandomProblemCommand(1L, 1L));
+        assertThat(result.problemId()).isEqualTo(101L);
+    }
+}

--- a/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
+++ b/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
@@ -1,0 +1,159 @@
+package com.project.quiz.solving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
+import com.project.quiz.infrastructure.persistence.entity.ChapterJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
+import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
+import com.project.quiz.domain.problem.ProblemType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = com.project.quiz.QuizBootstrapApplication.class)
+@AutoConfigureMockMvc
+class GetRandomProblemEndToEndTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ChapterJpaRepository chapterJpaRepository;
+
+    @Autowired
+    private ProblemJpaRepository problemJpaRepository;
+
+    @Autowired
+    private ProblemChoiceJpaRepository problemChoiceJpaRepository;
+
+    @Autowired
+    private SolveAttemptJpaRepository solveAttemptJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        solveAttemptJpaRepository.deleteAll();
+        problemChoiceJpaRepository.deleteAll();
+        problemJpaRepository.deleteAll();
+        chapterJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("실제 포트 구현이 연결된 상태에서 랜덤 문제를 조회한다")
+    void getRandomProblemEndToEnd() throws Exception {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.saveAll(List.of(
+                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemType.SINGLE_ANSWER),
+                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemType.SINGLE_ANSWER),
+                ProblemJpaEntity.create(102L, 1L, "출제될 문제", ProblemType.MULTIPLE_ANSWER)
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(100L, 1, "100-1"),
+                ProblemChoiceJpaEntity.create(100L, 2, "100-2"),
+                ProblemChoiceJpaEntity.create(101L, 1, "101-1"),
+                ProblemChoiceJpaEntity.create(101L, 2, "101-2"),
+                ProblemChoiceJpaEntity.create(102L, 1, "102-1"),
+                ProblemChoiceJpaEntity.create(102L, 2, "102-2"),
+                ProblemChoiceJpaEntity.create(102L, 3, "102-3"),
+                ProblemChoiceJpaEntity.create(102L, 4, "102-4"),
+                ProblemChoiceJpaEntity.create(102L, 5, "102-5")
+        ));
+        solveAttemptJpaRepository.saveAll(List.of(
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1)),
+                SolveAttemptJpaEntity.create(2L, 1L, 102L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusSeconds(50)),
+                SolveAttemptJpaEntity.create(3L, 1L, 102L, AttemptStatus.SOLVED, false, LocalDateTime.now().minusSeconds(40)),
+                SolveAttemptJpaEntity.create(4L, 1L, 102L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusSeconds(30))
+        ));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "chapterId", 1L,
+                                "userId", 1L
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(102))
+                .andExpect(jsonPath("$.content").value("출제될 문제"))
+                .andExpect(jsonPath("$.choices[0]").value("102-1"))
+                .andExpect(jsonPath("$.choices[4]").value("102-5"))
+                .andExpect(jsonPath("$.answerCorrectRate").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("모든 문제가 이미 풀었거나 직전 스킵이면 409를 반환한다")
+    void returnConflictWhenNoAvailableProblemExistsEndToEnd() throws Exception {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.saveAll(List.of(
+                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemType.SINGLE_ANSWER),
+                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemType.SINGLE_ANSWER)
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(100L, 1, "100-1"),
+                ProblemChoiceJpaEntity.create(101L, 1, "101-1")
+        ));
+        solveAttemptJpaRepository.saveAll(List.of(
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1))
+        ));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "chapterId", 1L,
+                                "userId", 1L
+                        ))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"));
+    }
+
+    @Test
+    @DisplayName("문제 넘기기를 호출하면 skip 기록 후 다음 문제를 반환한다")
+    void skipProblemAndReturnNextRandomProblemEndToEnd() throws Exception {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.saveAll(List.of(
+                ProblemJpaEntity.create(1001L, 1L, "현재 문제", ProblemType.SINGLE_ANSWER),
+                ProblemJpaEntity.create(1002L, 1L, "다음 문제", ProblemType.SINGLE_ANSWER)
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(1001L, 1, "1001-1"),
+                ProblemChoiceJpaEntity.create(1002L, 1, "1002-1"),
+                ProblemChoiceJpaEntity.create(1002L, 2, "1002-2"),
+                ProblemChoiceJpaEntity.create(1002L, 3, "1002-3"),
+                ProblemChoiceJpaEntity.create(1002L, 4, "1002-4"),
+                ProblemChoiceJpaEntity.create(1002L, 5, "1002-5")
+        ));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "chapterId", 1L,
+                                "userId", 1L,
+                                "problemId", 1001L
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(1002))
+                .andExpect(jsonPath("$.content").value("다음 문제"));
+    }
+}

--- a/quiz-bootstrap/src/test/resources/application.yaml
+++ b/quiz-bootstrap/src/test/resources/application.yaml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:teamsky;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: false
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /api-docs

--- a/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/TestInfrastructureApplication.java
+++ b/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/TestInfrastructureApplication.java
@@ -1,0 +1,9 @@
+package com.project.quiz.infrastructure;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+public class TestInfrastructureApplication {
+}

--- a/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapterTest.java
+++ b/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapterTest.java
@@ -1,0 +1,128 @@
+package com.project.quiz.infrastructure.solving;
+
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.solving.UserChapterSolvingState;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import com.project.quiz.infrastructure.TestInfrastructureApplication;
+import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
+import com.project.quiz.infrastructure.persistence.entity.ChapterJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
+import com.project.quiz.infrastructure.persistence.mapper.ProblemMapper;
+import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({RandomProblemPersistenceAdapter.class, ProblemMapper.class})
+@ContextConfiguration(classes = TestInfrastructureApplication.class)
+class RandomProblemPersistenceAdapterTest {
+
+    @Autowired
+    private RandomProblemPersistenceAdapter adapter;
+
+    @Autowired
+    private ChapterJpaRepository chapterJpaRepository;
+
+    @Autowired
+    private ProblemJpaRepository problemJpaRepository;
+
+    @Autowired
+    private ProblemChoiceJpaRepository problemChoiceJpaRepository;
+
+    @Autowired
+    private SolveAttemptJpaRepository solveAttemptJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        solveAttemptJpaRepository.deleteAll();
+        problemChoiceJpaRepository.deleteAll();
+        problemJpaRepository.deleteAll();
+        chapterJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("chapter 문제와 선택지를 domain problem으로 조합해 조회한다")
+    void loadProblemsByChapterId() {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.saveAll(List.of(
+                ProblemJpaEntity.create(100L, 1L, "problem-1", ProblemType.SINGLE_ANSWER),
+                ProblemJpaEntity.create(101L, 1L, "problem-2", ProblemType.MULTIPLE_ANSWER)
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(100L, 1, "p1-choice-1"),
+                ProblemChoiceJpaEntity.create(100L, 2, "p1-choice-2"),
+                ProblemChoiceJpaEntity.create(101L, 1, "p2-choice-1"),
+                ProblemChoiceJpaEntity.create(101L, 2, "p2-choice-2")
+        ));
+
+        List<Problem> problems = adapter.loadByChapterId(1L);
+
+        assertThat(problems).hasSize(2);
+        assertThat(problems.get(0).id()).isEqualTo(100L);
+        assertThat(problems.get(0).chapterId()).isEqualTo(1L);
+        assertThat(problems.get(0).choices()).extracting(choice -> choice.content())
+                .containsExactly("p1-choice-1", "p1-choice-2");
+        assertThat(problems.get(1).type()).isEqualTo(ProblemType.MULTIPLE_ANSWER);
+    }
+
+    @Test
+    @DisplayName("사용자 챕터 풀이 상태를 solved 목록과 마지막 skipped 문제로 조회한다")
+    void loadUserChapterSolvingState() {
+        solveAttemptJpaRepository.saveAll(List.of(
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(3)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 102L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1))
+        ));
+
+        UserChapterSolvingState state = adapter.load(1L, 1L);
+
+        assertThat(state.userId()).isEqualTo(1L);
+        assertThat(state.chapterId()).isEqualTo(1L);
+        assertThat(state.solvedProblemIds()).isEqualTo(Set.of(100L));
+        assertThat(state.lastSkippedProblemId()).isEqualTo(102L);
+    }
+
+    @Test
+    @DisplayName("문제 정답률 집계를 조회한다")
+    void loadProblemCorrectRateSummary() {
+        solveAttemptJpaRepository.saveAll(List.of(
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(3)),
+                SolveAttemptJpaEntity.create(2L, 1L, 100L, AttemptStatus.SOLVED, false, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(1)),
+                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SKIPPED, null, LocalDateTime.now())
+        ));
+
+        Optional<ProblemCorrectRateSummary> summary = adapter.loadByProblemId(100L);
+
+        assertThat(summary).isPresent();
+        assertThat(summary.get().solvedUserCount()).isEqualTo(3L);
+        assertThat(summary.get().correctUserCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("chapter 존재 여부를 확인한다")
+    void existsByChapterId() {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+
+        assertThat(adapter.existsById(1L)).isTrue();
+        assertThat(adapter.existsById(99L)).isFalse();
+    }
+}


### PR DESCRIPTION
## 요약
- 계층별 테스트를 추가하고 프로젝트 README를 작성했습니다.

## 변경 사항
- application unit test 추가
- API 슬라이스 테스트 추가
- infrastructure integration test 추가
- bootstrap end-to-end test 추가
- README 작성

## 설계 의도
테스트를 계층별로 분리해
- 규칙 검증
- HTTP 계약 검증
- persistence 검증
- 실제 계층 연결 검증
을 각각 독립적으로 확인할 수 있게 했습니다.

README에는 DDD 관점, 멀티 모듈 분리 이유, 실행 방법, 성능 관점을 함께 정리했습니다.

## 검증
실행한 명령:
```bash
./gradlew :quiz-application:test
./gradlew :quiz-api:test
./gradlew :quiz-infrastructure:test
./gradlew :quiz-bootstrap:test

## 영향 범위

- 테스트 코드 전반
- README
