### PR TITLE
[Feat] 문제 제출 API 구현

### DIFF
--- a/docker/mysql/init/01-schema-and-seed.sql
+++ b/docker/mysql/init/01-schema-and-seed.sql
@@ -12,7 +12,9 @@ CREATE TABLE IF NOT EXISTS problems (
     id BIGINT NOT NULL PRIMARY KEY,
     chapter_id BIGINT NOT NULL,
     content TEXT NOT NULL,
+    answer_format VARCHAR(30) NOT NULL,
     problem_type VARCHAR(30) NOT NULL,
+    explanation TEXT NOT NULL,
     CONSTRAINT fk_problems_chapter FOREIGN KEY (chapter_id) REFERENCES chapters (id)
 );
 
@@ -31,6 +33,7 @@ CREATE TABLE IF NOT EXISTS solve_attempts (
     problem_id BIGINT NOT NULL,
     status VARCHAR(20) NOT NULL,
     is_correct BIT NULL,
+    answer_status VARCHAR(20) NULL,
     created_at DATETIME NOT NULL,
     INDEX idx_solve_attempts_user_chapter (user_id, chapter_id),
     INDEX idx_solve_attempts_problem (problem_id),
@@ -39,22 +42,43 @@ CREATE TABLE IF NOT EXISTS solve_attempts (
     CONSTRAINT fk_solve_attempts_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
 );
 
+CREATE TABLE IF NOT EXISTS problem_answer_keys (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    problem_id BIGINT NOT NULL,
+    answer_format VARCHAR(30) NOT NULL,
+    choice_sequence INT NULL,
+    subjective_answer TEXT NULL,
+    CONSTRAINT fk_problem_answer_keys_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
+);
+
+CREATE TABLE IF NOT EXISTS solve_attempt_answers (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    solve_attempt_id BIGINT NOT NULL,
+    answer_format VARCHAR(30) NOT NULL,
+    choice_sequence INT NULL,
+    subjective_answer TEXT NULL,
+    CONSTRAINT fk_solve_attempt_answers_attempt FOREIGN KEY (solve_attempt_id) REFERENCES solve_attempts (id)
+);
+
 INSERT INTO chapters (id, title) VALUES
     (1, 'Java Basics'),
     (2, 'Spring Core')
 ON DUPLICATE KEY UPDATE title = VALUES(title);
 
-INSERT INTO problems (id, chapter_id, content, problem_type) VALUES
-    (1001, 1, 'Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.', 'SINGLE_ANSWER'),
-    (1002, 1, 'JVM 메모리 영역에 대한 설명으로 옳은 것을 모두 고르세요.', 'MULTIPLE_ANSWER'),
-    (1003, 1, 'List와 Set의 차이로 가장 적절한 것을 고르세요.', 'SINGLE_ANSWER'),
-    (1004, 1, '예외 처리 방식으로 적절한 것을 모두 고르세요.', 'MULTIPLE_ANSWER'),
-    (2001, 2, 'Spring Bean의 기본 scope는 무엇인가요?', 'SINGLE_ANSWER'),
-    (2002, 2, '트랜잭션 전파 속성에 대한 설명으로 옳은 것을 모두 고르세요.', 'MULTIPLE_ANSWER')
+INSERT INTO problems (id, chapter_id, content, answer_format, problem_type, explanation) VALUES
+    (1001, 1, 'Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.', 'OBJECTIVE', 'SINGLE_ANSWER', '정답은 boolean 입니다.'),
+    (1002, 1, 'JVM 메모리 영역에 대한 설명으로 옳은 것을 모두 고르세요.', 'OBJECTIVE', 'MULTIPLE_ANSWER', 'Heap, Method Area, PC Register 관련 설명이 정답입니다.'),
+    (1003, 1, 'List와 Set의 차이로 가장 적절한 것을 고르세요.', 'OBJECTIVE', 'SINGLE_ANSWER', 'List는 중복 허용, Set은 중복 비허용이 핵심 차이입니다.'),
+    (1004, 1, '예외 처리 방식으로 적절한 것을 모두 고르세요.', 'OBJECTIVE', 'MULTIPLE_ANSWER', '복구 가능성과 일관된 오류 응답이 핵심입니다.'),
+    (2001, 2, 'Spring Bean의 기본 scope는 무엇인가요?', 'OBJECTIVE', 'SINGLE_ANSWER', '기본 scope는 singleton 입니다.'),
+    (2002, 2, '트랜잭션 전파 속성에 대한 설명으로 옳은 것을 모두 고르세요.', 'OBJECTIVE', 'MULTIPLE_ANSWER', 'REQUIRED, REQUIRES_NEW, SUPPORTS가 정답입니다.'),
+    (2003, 2, 'Spring에서 기본 Bean scope 이름을 입력하세요.', 'SUBJECTIVE', 'SINGLE_ANSWER', '기본 Bean scope 이름은 singleton 입니다.')
 ON DUPLICATE KEY UPDATE
     chapter_id = VALUES(chapter_id),
     content = VALUES(content),
-    problem_type = VALUES(problem_type);
+    answer_format = VALUES(answer_format),
+    problem_type = VALUES(problem_type),
+    explanation = VALUES(explanation);
 
 INSERT INTO problem_choices (problem_id, sequence, content) VALUES
     (1001, 1, 'int'),
@@ -96,47 +120,63 @@ ON DUPLICATE KEY UPDATE
     sequence = VALUES(sequence),
     content = VALUES(content);
 
-INSERT INTO solve_attempts (user_id, chapter_id, problem_id, status, is_correct, created_at) VALUES
-    (1, 1, 1003, 'SOLVED', b'1', '2026-03-26 10:00:00'),
-    (1, 1, 1002, 'SKIPPED', NULL, '2026-03-26 10:05:00'),
-    (2, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:00:00'),
-    (3, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:01:00'),
-    (4, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:02:00'),
-    (5, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:03:00'),
-    (6, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:04:00'),
-    (7, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:05:00'),
-    (8, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:06:00'),
-    (9, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:07:00'),
-    (10, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:08:00'),
-    (11, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:09:00'),
-    (12, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:10:00'),
-    (13, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:11:00'),
-    (14, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:12:00'),
-    (15, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:13:00'),
-    (16, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:14:00'),
-    (17, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:15:00'),
-    (18, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:16:00'),
-    (19, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:17:00'),
-    (20, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:18:00'),
-    (21, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:19:00'),
-    (22, 1, 1001, 'SOLVED', b'1', '2026-03-26 09:20:00'),
-    (23, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:21:00'),
-    (24, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:22:00'),
-    (25, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:23:00'),
-    (26, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:24:00'),
-    (27, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:25:00'),
-    (28, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:26:00'),
-    (29, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:27:00'),
-    (30, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:28:00'),
-    (31, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:29:00'),
-    (32, 1, 1001, 'SOLVED', b'0', '2026-03-26 09:30:00'),
-    (2, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:00:00'),
-    (3, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:01:00'),
-    (4, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:02:00'),
-    (5, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:03:00'),
-    (6, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:04:00'),
-    (7, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:05:00'),
-    (8, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:06:00'),
-    (9, 1, 1004, 'SOLVED', b'0', '2026-03-26 11:07:00'),
-    (10, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:08:00'),
-    (11, 1, 1004, 'SOLVED', b'1', '2026-03-26 11:09:00');
+INSERT INTO problem_answer_keys (problem_id, answer_format, choice_sequence, subjective_answer) VALUES
+    (1001, 'OBJECTIVE', 3, NULL),
+    (1002, 'OBJECTIVE', 1, NULL),
+    (1002, 'OBJECTIVE', 2, NULL),
+    (1002, 'OBJECTIVE', 4, NULL),
+    (1003, 'OBJECTIVE', 2, NULL),
+    (1004, 'OBJECTIVE', 1, NULL),
+    (1004, 'OBJECTIVE', 3, NULL),
+    (1004, 'OBJECTIVE', 4, NULL),
+    (2001, 'OBJECTIVE', 2, NULL),
+    (2002, 'OBJECTIVE', 1, NULL),
+    (2002, 'OBJECTIVE', 2, NULL),
+    (2002, 'OBJECTIVE', 4, NULL),
+    (2003, 'SUBJECTIVE', NULL, 'singleton'),
+    (2003, 'SUBJECTIVE', NULL, '싱글톤');
+
+INSERT INTO solve_attempts (user_id, chapter_id, problem_id, status, is_correct, answer_status, created_at) VALUES
+    (1, 1, 1003, 'SOLVED', b'1', 'CORRECT', '2026-03-26 10:00:00'),
+    (1, 1, 1002, 'SKIPPED', NULL, NULL, '2026-03-26 10:05:00'),
+    (2, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:00:00'),
+    (3, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:01:00'),
+    (4, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:02:00'),
+    (5, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:03:00'),
+    (6, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:04:00'),
+    (7, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:05:00'),
+    (8, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:06:00'),
+    (9, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:07:00'),
+    (10, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:08:00'),
+    (11, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:09:00'),
+    (12, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:10:00'),
+    (13, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:11:00'),
+    (14, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:12:00'),
+    (15, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:13:00'),
+    (16, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:14:00'),
+    (17, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:15:00'),
+    (18, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:16:00'),
+    (19, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:17:00'),
+    (20, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:18:00'),
+    (21, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:19:00'),
+    (22, 1, 1001, 'SOLVED', b'1', 'CORRECT', '2026-03-26 09:20:00'),
+    (23, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:21:00'),
+    (24, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:22:00'),
+    (25, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:23:00'),
+    (26, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:24:00'),
+    (27, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:25:00'),
+    (28, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:26:00'),
+    (29, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:27:00'),
+    (30, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:28:00'),
+    (31, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:29:00'),
+    (32, 1, 1001, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 09:30:00'),
+    (2, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:00:00'),
+    (3, 1, 1004, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 11:01:00'),
+    (4, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:02:00'),
+    (5, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:03:00'),
+    (6, 1, 1004, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 11:04:00'),
+    (7, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:05:00'),
+    (8, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:06:00'),
+    (9, 1, 1004, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 11:07:00'),
+    (10, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:08:00'),
+    (11, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:09:00');

--- a/quiz-api/build.gradle
+++ b/quiz-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':quiz-application')
+    implementation project(':quiz-domain')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.project.quiz.api.common;
 
 import com.project.quiz.application.solving.exception.ChapterNotFoundException;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +32,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleProblemNotFoundInChapter(ProblemNotFoundInChapterException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse("PROBLEM_NOT_FOUND_IN_CHAPTER", exception.getMessage()));
+    }
+
+    @ExceptionHandler(ProblemAnswerTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleProblemAnswerTypeMismatch(ProblemAnswerTypeMismatchException exception) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("PROBLEM_ANSWER_TYPE_MISMATCH", exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerController.java
@@ -1,0 +1,59 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerCommand;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerUseCase;
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "단원별 문제 풀이", description = "단원별 랜덤 문제 조회와 풀이 관련 엔드포인트")
+@RestController
+@RequestMapping("/api/problems")
+@RequiredArgsConstructor
+public class SubmitProblemAnswerController {
+
+    private final SubmitProblemAnswerUseCase submitProblemAnswerUseCase;
+
+    @Operation(summary = "문제 제출", description = "객관식 또는 주관식 답안을 제출하고 즉시 채점 결과와 해설을 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문제 제출이 정상적으로 처리되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "문제를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "문제의 답안 형식과 제출 형식이 일치하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/submit")
+    public ResponseEntity<SubmitProblemAnswerResponse> submit(@Valid @RequestBody SubmitProblemAnswerRequest request) {
+        SubmitProblemAnswerResult result = submitProblemAnswerUseCase.submit(
+                new SubmitProblemAnswerCommand(
+                        request.problemId(),
+                        request.userId(),
+                        request.answerType(),
+                        request.selectedChoices(),
+                        request.subjectiveAnswer()
+                )
+        );
+
+        return ResponseEntity.ok(new SubmitProblemAnswerResponse(
+                result.problemId(),
+                result.answerType(),
+                result.answerStatus(),
+                result.explanation(),
+                result.problemAnswers()
+        ));
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerRequest.java
@@ -1,0 +1,34 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+@Schema(description = "문제 제출 요청")
+@ValidSubmitProblemAnswerRequest
+public record SubmitProblemAnswerRequest(
+        @Schema(description = "문제 ID", example = "1001")
+        @NotNull(message = "problemId is required")
+        @Positive(message = "problemId must be positive")
+        Long problemId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId,
+
+        @Schema(description = "답안 형식", example = "OBJECTIVE")
+        @NotNull(message = "answerType is required")
+        ProblemAnswerFormat answerType,
+
+        @ArraySchema(schema = @Schema(description = "객관식 선택지 번호 목록", example = "1"))
+        List<Integer> selectedChoices,
+
+        @Schema(description = "주관식 답안", example = "싱글톤")
+        String subjectiveAnswer
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerRequestValidator.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerRequestValidator.java
@@ -1,0 +1,36 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class SubmitProblemAnswerRequestValidator implements ConstraintValidator<ValidSubmitProblemAnswerRequest, SubmitProblemAnswerRequest> {
+
+    @Override
+    public boolean isValid(SubmitProblemAnswerRequest value, ConstraintValidatorContext context) {
+        if (value == null || value.answerType() == null) {
+            return true;
+        }
+
+        context.disableDefaultConstraintViolation();
+
+        if (value.answerType() == ProblemAnswerFormat.OBJECTIVE) {
+            if (value.selectedChoices() == null || value.selectedChoices().isEmpty()) {
+                context.buildConstraintViolationWithTemplate("selectedChoices must not be empty for OBJECTIVE answerType")
+                        .addPropertyNode("selectedChoices")
+                        .addConstraintViolation();
+                return false;
+            }
+            return true;
+        }
+
+        if (value.subjectiveAnswer() == null || value.subjectiveAnswer().isBlank()) {
+            context.buildConstraintViolationWithTemplate("subjectiveAnswer must not be blank for SUBJECTIVE answerType")
+                    .addPropertyNode("subjectiveAnswer")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/SubmitProblemAnswerResponse.java
@@ -1,0 +1,23 @@
+package com.project.quiz.api.solving;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "문제 제출 응답")
+public record SubmitProblemAnswerResponse(
+        @Schema(description = "문제 ID", example = "1001")
+        Long problemId,
+        @Schema(description = "답안 형식", example = "OBJECTIVE")
+        ProblemAnswerFormat answerType,
+        @Schema(description = "채점 결과", example = "PARTIAL")
+        AnswerStatus answerStatus,
+        @Schema(description = "문제 해설", example = "정답은 boolean 입니다.")
+        String explanation,
+        @ArraySchema(schema = @Schema(description = "정답 목록", example = "3"))
+        List<String> problemAnswers
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/solving/ValidSubmitProblemAnswerRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/solving/ValidSubmitProblemAnswerRequest.java
@@ -1,0 +1,21 @@
+package com.project.quiz.api.solving;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SubmitProblemAnswerRequestValidator.class)
+public @interface ValidSubmitProblemAnswerRequest {
+
+    String message() default "invalid submit problem answer request";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/quiz-api/src/test/java/com/project/quiz/api/solving/SubmitProblemAnswerControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/solving/SubmitProblemAnswerControllerTest.java
@@ -1,0 +1,108 @@
+package com.project.quiz.api.solving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerUseCase;
+import com.project.quiz.api.TestApiApplication;
+import com.project.quiz.api.common.GlobalExceptionHandler;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SubmitProblemAnswerController.class)
+@ContextConfiguration(classes = {
+        TestApiApplication.class,
+        SubmitProblemAnswerController.class,
+        GlobalExceptionHandler.class
+})
+class SubmitProblemAnswerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SubmitProblemAnswerUseCase submitProblemAnswerUseCase;
+
+    @Test
+    @DisplayName("정상 제출이면 채점 결과를 반환한다")
+    void returnGradingResult() throws Exception {
+        when(submitProblemAnswerUseCase.submit(any()))
+                .thenReturn(new SubmitProblemAnswerResult(1001L, ProblemAnswerFormat.OBJECTIVE, AnswerStatus.PARTIAL, "해설", List.of("1", "2")));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(1001))
+                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.problemAnswers[0]").value("1"));
+    }
+
+    @Test
+    @DisplayName("문제를 찾을 수 없으면 404를 반환한다")
+    void returnNotFoundWhenProblemMissing() throws Exception {
+        when(submitProblemAnswerUseCase.submit(any()))
+                .thenThrow(new ProblemNotFoundInChapterException(null, 999L));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(999L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+    }
+
+    @Test
+    @DisplayName("답안 형식이 맞지 않으면 409를 반환한다")
+    void returnConflictWhenAnswerTypeMismatch() throws Exception {
+        when(submitProblemAnswerUseCase.submit(any()))
+                .thenThrow(new ProblemAnswerTypeMismatchException(1001L));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PROBLEM_ANSWER_TYPE_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("객관식 제출에서 선택지가 비어 있으면 400을 반환한다")
+    void returnBadRequestWhenObjectiveChoicesMissing() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(), null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must not be empty for OBJECTIVE answerType"));
+    }
+
+    @Test
+    @DisplayName("주관식 제출에서 답안이 비어 있으면 400을 반환한다")
+    void returnBadRequestWhenSubjectiveAnswerMissing() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, null, "   "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must not be blank for SUBJECTIVE answerType"));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemAnswerTypeMismatchException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemAnswerTypeMismatchException.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.exception;
+
+public class ProblemAnswerTypeMismatchException extends RuntimeException {
+
+    public ProblemAnswerTypeMismatchException(Long problemId) {
+        super("Problem answer type mismatch. problemId=" + problemId);
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemNotFoundInChapterException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/ProblemNotFoundInChapterException.java
@@ -3,6 +3,8 @@ package com.project.quiz.application.solving.exception;
 public class ProblemNotFoundInChapterException extends RuntimeException {
 
     public ProblemNotFoundInChapterException(Long chapterId, Long problemId) {
-        super("Problem not found in chapter. chapterId=%d, problemId=%d".formatted(chapterId, problemId));
+        super(chapterId == null
+                ? "Problem not found. problemId=%d".formatted(problemId)
+                : "Problem not found in chapter. chapterId=%d, problemId=%d".formatted(chapterId, problemId));
     }
 }

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerCommand.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerCommand.java
@@ -1,0 +1,14 @@
+package com.project.quiz.application.solving.port.in;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+
+import java.util.List;
+
+public record SubmitProblemAnswerCommand(
+        Long problemId,
+        Long userId,
+        ProblemAnswerFormat answerType,
+        List<Integer> selectedChoices,
+        String subjectiveAnswer
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerResult.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerResult.java
@@ -1,0 +1,15 @@
+package com.project.quiz.application.solving.port.in;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+
+import java.util.List;
+
+public record SubmitProblemAnswerResult(
+        Long problemId,
+        ProblemAnswerFormat answerType,
+        AnswerStatus answerStatus,
+        String explanation,
+        List<String> problemAnswers
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerUseCase.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/in/SubmitProblemAnswerUseCase.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.solving.port.in;
+
+public interface SubmitProblemAnswerUseCase {
+
+    SubmitProblemAnswerResult submit(SubmitProblemAnswerCommand command);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadProblemDetailPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/LoadProblemDetailPort.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.problem.Problem;
+
+import java.util.Optional;
+
+public interface LoadProblemDetailPort {
+
+    Optional<Problem> loadById(Long problemId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/SaveSolvedAttemptPort.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/port/out/SaveSolvedAttemptPort.java
@@ -1,0 +1,9 @@
+package com.project.quiz.application.solving.port.out;
+
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.solving.SubmittedAnswer;
+
+public interface SaveSolvedAttemptPort {
+
+    void saveSolvedAttempt(Long userId, Long chapterId, Long problemId, SubmittedAnswer answer, AnswerStatus answerStatus);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/SubmitProblemAnswerService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/SubmitProblemAnswerService.java
@@ -1,0 +1,62 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerCommand;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerUseCase;
+import com.project.quiz.application.solving.port.out.LoadProblemDetailPort;
+import com.project.quiz.application.solving.port.out.SaveSolvedAttemptPort;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.solving.GradingResult;
+import com.project.quiz.domain.solving.SubmittedAnswer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class SubmitProblemAnswerService implements SubmitProblemAnswerUseCase {
+
+    private final LoadProblemDetailPort loadProblemDetailPort;
+    private final SaveSolvedAttemptPort saveSolvedAttemptPort;
+
+    @Override
+    @Transactional
+    public SubmitProblemAnswerResult submit(SubmitProblemAnswerCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        Problem problem = loadProblemDetailPort.loadById(command.problemId())
+                .orElseThrow(() -> new ProblemNotFoundInChapterException(null, command.problemId()));
+
+        if (problem.answerFormat() != command.answerType()) {
+            throw new ProblemAnswerTypeMismatchException(command.problemId());
+        }
+
+        SubmittedAnswer submittedAnswer = new SubmittedAnswer(
+                command.answerType(),
+                command.selectedChoices(),
+                command.subjectiveAnswer()
+        );
+
+        GradingResult gradingResult = problem.grade(submittedAnswer);
+
+        saveSolvedAttemptPort.saveSolvedAttempt(
+                command.userId(),
+                problem.chapterId(),
+                problem.id(),
+                submittedAnswer,
+                gradingResult.answerStatus()
+        );
+
+        return new SubmitProblemAnswerResult(
+                gradingResult.problemId(),
+                gradingResult.answerFormat(),
+                gradingResult.answerStatus(),
+                gradingResult.explanation(),
+                gradingResult.problemAnswers()
+        );
+    }
+}

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetRandomProblemServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetRandomProblemServiceTest.java
@@ -9,6 +9,8 @@ import com.project.quiz.application.solving.port.out.LoadUserChapterSolvingState
 import com.project.quiz.application.solving.port.out.PickRandomProblemPort;
 import com.project.quiz.application.solving.exception.ChapterNotFoundException;
 import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.problem.ProblemAnswerKey;
 import com.project.quiz.domain.problem.ProblemChoice;
 import com.project.quiz.domain.problem.ProblemType;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
@@ -140,6 +142,7 @@ class GetRandomProblemServiceTest {
                 problemId,
                 chapterId,
                 content,
+                ProblemAnswerFormat.OBJECTIVE,
                 ProblemType.SINGLE_ANSWER,
                 List.of(
                         new ProblemChoice(1, "choice-1"),
@@ -147,7 +150,9 @@ class GetRandomProblemServiceTest {
                         new ProblemChoice(3, "choice-3"),
                         new ProblemChoice(4, "choice-4"),
                         new ProblemChoice(5, "choice-5")
-                )
+                ),
+                new ProblemAnswerKey(Set.of(1), List.of()),
+                "해설"
         );
     }
 }

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/SubmitProblemAnswerServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/SubmitProblemAnswerServiceTest.java
@@ -1,0 +1,108 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerCommand;
+import com.project.quiz.application.solving.port.in.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.port.out.LoadProblemDetailPort;
+import com.project.quiz.application.solving.port.out.SaveSolvedAttemptPort;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.problem.ProblemAnswerKey;
+import com.project.quiz.domain.problem.ProblemChoice;
+import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.solving.AnswerStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubmitProblemAnswerServiceTest {
+
+    @Mock
+    private LoadProblemDetailPort loadProblemDetailPort;
+
+    @Mock
+    private SaveSolvedAttemptPort saveSolvedAttemptPort;
+
+    private SubmitProblemAnswerService submitProblemAnswerService;
+
+    @BeforeEach
+    void setUp() {
+        submitProblemAnswerService = new SubmitProblemAnswerService(loadProblemDetailPort, saveSolvedAttemptPort);
+    }
+
+    @Test
+    void objectiveCorrectAnswerReturnsCorrect() {
+        Problem problem = new Problem(
+                100L, 1L, "problem", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER,
+                List.of(new ProblemChoice(1, "a"), new ProblemChoice(2, "b")),
+                new ProblemAnswerKey(Set.of(1, 2), List.of()),
+                "해설"
+        );
+        when(loadProblemDetailPort.loadById(100L)).thenReturn(Optional.of(problem));
+
+        SubmitProblemAnswerResult result = submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(100L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 2), null)
+        );
+
+        assertThat(result.answerStatus()).isEqualTo(AnswerStatus.CORRECT);
+        assertThat(result.problemAnswers()).containsExactly("1", "2");
+        verify(saveSolvedAttemptPort).saveSolvedAttempt(1L, 1L, 100L,
+                new com.project.quiz.domain.solving.SubmittedAnswer(ProblemAnswerFormat.OBJECTIVE, List.of(1, 2), null),
+                AnswerStatus.CORRECT);
+    }
+
+    @Test
+    void objectivePartialAnswerReturnsPartial() {
+        Problem problem = new Problem(
+                100L, 1L, "problem", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER,
+                List.of(), new ProblemAnswerKey(Set.of(1, 2), List.of()), "해설"
+        );
+        when(loadProblemDetailPort.loadById(100L)).thenReturn(Optional.of(problem));
+
+        SubmitProblemAnswerResult result = submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(100L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null)
+        );
+
+        assertThat(result.answerStatus()).isEqualTo(AnswerStatus.PARTIAL);
+    }
+
+    @Test
+    void subjectiveCorrectAnswerReturnsCorrect() {
+        Problem problem = new Problem(
+                200L, 1L, "problem", ProblemAnswerFormat.SUBJECTIVE, ProblemType.SINGLE_ANSWER,
+                List.of(), new ProblemAnswerKey(Set.of(), List.of("싱글톤", "singleton")), "해설"
+        );
+        when(loadProblemDetailPort.loadById(200L)).thenReturn(Optional.of(problem));
+
+        SubmitProblemAnswerResult result = submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(200L, 1L, ProblemAnswerFormat.SUBJECTIVE, null, " singleton ")
+        );
+
+        assertThat(result.answerStatus()).isEqualTo(AnswerStatus.CORRECT);
+    }
+
+    @Test
+    void answerTypeMismatchThrowsException() {
+        Problem problem = new Problem(
+                200L, 1L, "problem", ProblemAnswerFormat.SUBJECTIVE, ProblemType.SINGLE_ANSWER,
+                List.of(), new ProblemAnswerKey(Set.of(), List.of("싱글톤")), "해설"
+        );
+        when(loadProblemDetailPort.loadById(200L)).thenReturn(Optional.of(problem));
+
+        assertThatThrownBy(() -> submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(200L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null)
+        )).isInstanceOf(ProblemAnswerTypeMismatchException.class);
+    }
+}

--- a/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
+++ b/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
@@ -3,14 +3,19 @@ package com.project.quiz.solving;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
 import com.project.quiz.infrastructure.persistence.entity.ChapterJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemAnswerKeyJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
+import com.project.quiz.infrastructure.persistence.repository.ProblemAnswerKeyJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptAnswerJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.solving.AnswerStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,11 +54,19 @@ class GetRandomProblemEndToEndTest {
     private ProblemChoiceJpaRepository problemChoiceJpaRepository;
 
     @Autowired
+    private ProblemAnswerKeyJpaRepository problemAnswerKeyJpaRepository;
+
+    @Autowired
     private SolveAttemptJpaRepository solveAttemptJpaRepository;
+
+    @Autowired
+    private SolveAttemptAnswerJpaRepository solveAttemptAnswerJpaRepository;
 
     @BeforeEach
     void setUp() {
+        solveAttemptAnswerJpaRepository.deleteAll();
         solveAttemptJpaRepository.deleteAll();
+        problemAnswerKeyJpaRepository.deleteAll();
         problemChoiceJpaRepository.deleteAll();
         problemJpaRepository.deleteAll();
         chapterJpaRepository.deleteAll();
@@ -64,9 +77,9 @@ class GetRandomProblemEndToEndTest {
     void getRandomProblemEndToEnd() throws Exception {
         chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
         problemJpaRepository.saveAll(List.of(
-                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemType.SINGLE_ANSWER),
-                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemType.SINGLE_ANSWER),
-                ProblemJpaEntity.create(102L, 1L, "출제될 문제", ProblemType.MULTIPLE_ANSWER)
+                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설"),
+                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설"),
+                ProblemJpaEntity.create(102L, 1L, "출제될 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER, "해설")
         ));
         problemChoiceJpaRepository.saveAll(List.of(
                 ProblemChoiceJpaEntity.create(100L, 1, "100-1"),
@@ -79,12 +92,18 @@ class GetRandomProblemEndToEndTest {
                 ProblemChoiceJpaEntity.create(102L, 4, "102-4"),
                 ProblemChoiceJpaEntity.create(102L, 5, "102-5")
         ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(100L, 1),
+                ProblemAnswerKeyJpaEntity.objective(101L, 1),
+                ProblemAnswerKeyJpaEntity.objective(102L, 2),
+                ProblemAnswerKeyJpaEntity.objective(102L, 4)
+        ));
         solveAttemptJpaRepository.saveAll(List.of(
-                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(2)),
-                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1)),
-                SolveAttemptJpaEntity.create(2L, 1L, 102L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusSeconds(50)),
-                SolveAttemptJpaEntity.create(3L, 1L, 102L, AttemptStatus.SOLVED, false, LocalDateTime.now().minusSeconds(40)),
-                SolveAttemptJpaEntity.create(4L, 1L, 102L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusSeconds(30))
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now().minusMinutes(1)),
+                SolveAttemptJpaEntity.create(2L, 1L, 102L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusSeconds(50)),
+                SolveAttemptJpaEntity.create(3L, 1L, 102L, AttemptStatus.SOLVED, false, AnswerStatus.INCORRECT, LocalDateTime.now().minusSeconds(40)),
+                SolveAttemptJpaEntity.create(4L, 1L, 102L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusSeconds(30))
         ));
 
         mockMvc.perform(post("/api/problems/random")
@@ -106,16 +125,20 @@ class GetRandomProblemEndToEndTest {
     void returnConflictWhenNoAvailableProblemExistsEndToEnd() throws Exception {
         chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
         problemJpaRepository.saveAll(List.of(
-                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemType.SINGLE_ANSWER),
-                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemType.SINGLE_ANSWER)
+                ProblemJpaEntity.create(100L, 1L, "이미 푼 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설"),
+                ProblemJpaEntity.create(101L, 1L, "직전 스킵 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설")
         ));
         problemChoiceJpaRepository.saveAll(List.of(
                 ProblemChoiceJpaEntity.create(100L, 1, "100-1"),
                 ProblemChoiceJpaEntity.create(101L, 1, "101-1")
         ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(100L, 1),
+                ProblemAnswerKeyJpaEntity.objective(101L, 1)
+        ));
         solveAttemptJpaRepository.saveAll(List.of(
-                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(2)),
-                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1))
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now().minusMinutes(1))
         ));
 
         mockMvc.perform(post("/api/problems/random")
@@ -133,8 +156,8 @@ class GetRandomProblemEndToEndTest {
     void skipProblemAndReturnNextRandomProblemEndToEnd() throws Exception {
         chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
         problemJpaRepository.saveAll(List.of(
-                ProblemJpaEntity.create(1001L, 1L, "현재 문제", ProblemType.SINGLE_ANSWER),
-                ProblemJpaEntity.create(1002L, 1L, "다음 문제", ProblemType.SINGLE_ANSWER)
+                ProblemJpaEntity.create(1001L, 1L, "현재 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설"),
+                ProblemJpaEntity.create(1002L, 1L, "다음 문제", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "해설")
         ));
         problemChoiceJpaRepository.saveAll(List.of(
                 ProblemChoiceJpaEntity.create(1001L, 1, "1001-1"),
@@ -143,6 +166,10 @@ class GetRandomProblemEndToEndTest {
                 ProblemChoiceJpaEntity.create(1002L, 3, "1002-3"),
                 ProblemChoiceJpaEntity.create(1002L, 4, "1002-4"),
                 ProblemChoiceJpaEntity.create(1002L, 5, "1002-5")
+        ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(1001L, 1),
+                ProblemAnswerKeyJpaEntity.objective(1002L, 2)
         ));
 
         mockMvc.perform(post("/api/problems/skip")
@@ -155,5 +182,40 @@ class GetRandomProblemEndToEndTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.problemId").value(1002))
                 .andExpect(jsonPath("$.content").value("다음 문제"));
+    }
+
+    @Test
+    @DisplayName("문제 제출 시 채점 결과와 해설을 반환한다")
+    void submitProblemAnswerEndToEnd() throws Exception {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.save(ProblemJpaEntity.create(
+                3001L, 1L, "정답을 모두 고르세요", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER, "정답은 1번과 2번입니다."
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(3001L, 1, "선택지 1"),
+                ProblemChoiceJpaEntity.create(3001L, 2, "선택지 2"),
+                ProblemChoiceJpaEntity.create(3001L, 3, "선택지 3"),
+                ProblemChoiceJpaEntity.create(3001L, 4, "선택지 4"),
+                ProblemChoiceJpaEntity.create(3001L, 5, "선택지 5")
+        ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(3001L, 1),
+                ProblemAnswerKeyJpaEntity.objective(3001L, 2)
+        ));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "problemId", 3001L,
+                                "userId", 1L,
+                                "answerType", "OBJECTIVE",
+                                "selectedChoices", List.of(1, 3)
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(3001))
+                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.explanation").value("정답은 1번과 2번입니다."))
+                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.problemAnswers[1]").value("2"));
     }
 }

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/Problem.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/Problem.java
@@ -1,16 +1,75 @@
 package com.project.quiz.domain.problem;
 
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.solving.GradingResult;
+import com.project.quiz.domain.solving.SubmittedAnswer;
+
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public record Problem(
         Long id,
         Long chapterId,
         String content,
+        ProblemAnswerFormat answerFormat,
         ProblemType type,
-        List<ProblemChoice> choices
+        List<ProblemChoice> choices,
+        ProblemAnswerKey answerKey,
+        String explanation
 ) {
 
     public boolean belongsTo(Long targetChapterId) {
         return chapterId.equals(targetChapterId);
+    }
+
+    public GradingResult grade(SubmittedAnswer submittedAnswer) {
+        return switch (answerFormat) {
+            case OBJECTIVE -> gradeObjective(submittedAnswer);
+            case SUBJECTIVE -> gradeSubjective(submittedAnswer);
+        };
+    }
+
+    private GradingResult gradeObjective(SubmittedAnswer submittedAnswer) {
+        Set<Integer> correctAnswers = answerKey.objectiveAnswers();
+        Set<Integer> submittedChoices = submittedAnswer.selectedChoices() == null
+                ? Set.of()
+                : Set.copyOf(submittedAnswer.selectedChoices());
+
+        AnswerStatus answerStatus;
+        if (submittedChoices.equals(correctAnswers)) {
+            answerStatus = AnswerStatus.CORRECT;
+        } else if (submittedChoices.stream().anyMatch(correctAnswers::contains)) {
+            answerStatus = AnswerStatus.PARTIAL;
+        } else {
+            answerStatus = AnswerStatus.INCORRECT;
+        }
+
+        return new GradingResult(
+                id,
+                answerFormat,
+                answerStatus,
+                explanation,
+                correctAnswers.stream().sorted().map(String::valueOf).toList()
+        );
+    }
+
+    private GradingResult gradeSubjective(SubmittedAnswer submittedAnswer) {
+        String normalizedSubmittedAnswer = normalize(submittedAnswer.subjectiveAnswer());
+        boolean correct = answerKey.subjectiveAnswers().stream()
+                .map(this::normalize)
+                .anyMatch(normalizedSubmittedAnswer::equals);
+
+        return new GradingResult(
+                id,
+                answerFormat,
+                correct ? AnswerStatus.CORRECT : AnswerStatus.INCORRECT,
+                explanation,
+                answerKey.subjectiveAnswers()
+        );
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemAnswerFormat.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemAnswerFormat.java
@@ -1,0 +1,6 @@
+package com.project.quiz.domain.problem;
+
+public enum ProblemAnswerFormat {
+    OBJECTIVE,
+    SUBJECTIVE
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemAnswerKey.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/problem/ProblemAnswerKey.java
@@ -1,0 +1,10 @@
+package com.project.quiz.domain.problem;
+
+import java.util.List;
+import java.util.Set;
+
+public record ProblemAnswerKey(
+        Set<Integer> objectiveAnswers,
+        List<String> subjectiveAnswers
+) {
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/solving/AnswerStatus.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/solving/AnswerStatus.java
@@ -1,0 +1,7 @@
+package com.project.quiz.domain.solving;
+
+public enum AnswerStatus {
+    CORRECT,
+    PARTIAL,
+    INCORRECT
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/solving/GradingResult.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/solving/GradingResult.java
@@ -1,0 +1,14 @@
+package com.project.quiz.domain.solving;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+
+import java.util.List;
+
+public record GradingResult(
+        Long problemId,
+        ProblemAnswerFormat answerFormat,
+        AnswerStatus answerStatus,
+        String explanation,
+        List<String> problemAnswers
+) {
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/solving/SubmittedAnswer.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/solving/SubmittedAnswer.java
@@ -1,0 +1,12 @@
+package com.project.quiz.domain.solving;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+
+import java.util.List;
+
+public record SubmittedAnswer(
+        ProblemAnswerFormat answerFormat,
+        List<Integer> selectedChoices,
+        String subjectiveAnswer
+) {
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemAnswerKeyJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemAnswerKeyJpaEntity.java
@@ -1,0 +1,64 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "problem_answer_keys")
+public class ProblemAnswerKeyJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_format", nullable = false, length = 30)
+    private ProblemAnswerFormat answerFormat;
+
+    @Column(name = "choice_sequence")
+    private Integer choiceSequence;
+
+    @Column(name = "subjective_answer", columnDefinition = "text")
+    private String subjectiveAnswer;
+
+    protected ProblemAnswerKeyJpaEntity() {
+    }
+
+    public static ProblemAnswerKeyJpaEntity objective(Long problemId, Integer choiceSequence) {
+        ProblemAnswerKeyJpaEntity entity = new ProblemAnswerKeyJpaEntity();
+        entity.problemId = problemId;
+        entity.answerFormat = ProblemAnswerFormat.OBJECTIVE;
+        entity.choiceSequence = choiceSequence;
+        return entity;
+    }
+
+    public static ProblemAnswerKeyJpaEntity subjective(Long problemId, String subjectiveAnswer) {
+        ProblemAnswerKeyJpaEntity entity = new ProblemAnswerKeyJpaEntity();
+        entity.problemId = problemId;
+        entity.answerFormat = ProblemAnswerFormat.SUBJECTIVE;
+        entity.subjectiveAnswer = subjectiveAnswer;
+        return entity;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public Integer getChoiceSequence() {
+        return choiceSequence;
+    }
+
+    public String getSubjectiveAnswer() {
+        return subjectiveAnswer;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemJpaEntity.java
@@ -1,6 +1,7 @@
 package com.project.quiz.infrastructure.persistence.entity;
 
 import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -22,18 +23,34 @@ public class ProblemJpaEntity {
     private String content;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "answer_format", nullable = false, length = 30)
+    private ProblemAnswerFormat answerFormat;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "problem_type", nullable = false, length = 30)
     private ProblemType type;
+
+    @Column(nullable = false, columnDefinition = "text")
+    private String explanation;
 
     protected ProblemJpaEntity() {
     }
 
-    public static ProblemJpaEntity create(Long id, Long chapterId, String content, ProblemType type) {
+    public static ProblemJpaEntity create(
+            Long id,
+            Long chapterId,
+            String content,
+            ProblemAnswerFormat answerFormat,
+            ProblemType type,
+            String explanation
+    ) {
         ProblemJpaEntity entity = new ProblemJpaEntity();
         entity.id = id;
         entity.chapterId = chapterId;
         entity.content = content;
+        entity.answerFormat = answerFormat;
         entity.type = type;
+        entity.explanation = explanation;
         return entity;
     }
 
@@ -49,7 +66,15 @@ public class ProblemJpaEntity {
         return content;
     }
 
+    public ProblemAnswerFormat getAnswerFormat() {
+        return answerFormat;
+    }
+
     public ProblemType getType() {
         return type;
+    }
+
+    public String getExplanation() {
+        return explanation;
     }
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptAnswerJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptAnswerJpaEntity.java
@@ -1,0 +1,68 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "solve_attempt_answers")
+public class SolveAttemptAnswerJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "solve_attempt_id", nullable = false)
+    private Long solveAttemptId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_format", nullable = false, length = 30)
+    private ProblemAnswerFormat answerFormat;
+
+    @Column(name = "choice_sequence")
+    private Integer choiceSequence;
+
+    @Column(name = "subjective_answer", columnDefinition = "text")
+    private String subjectiveAnswer;
+
+    protected SolveAttemptAnswerJpaEntity() {
+    }
+
+    public static SolveAttemptAnswerJpaEntity objective(Long solveAttemptId, Integer choiceSequence) {
+        SolveAttemptAnswerJpaEntity entity = new SolveAttemptAnswerJpaEntity();
+        entity.solveAttemptId = solveAttemptId;
+        entity.answerFormat = ProblemAnswerFormat.OBJECTIVE;
+        entity.choiceSequence = choiceSequence;
+        return entity;
+    }
+
+    public static SolveAttemptAnswerJpaEntity subjective(Long solveAttemptId, String subjectiveAnswer) {
+        SolveAttemptAnswerJpaEntity entity = new SolveAttemptAnswerJpaEntity();
+        entity.solveAttemptId = solveAttemptId;
+        entity.answerFormat = ProblemAnswerFormat.SUBJECTIVE;
+        entity.subjectiveAnswer = subjectiveAnswer;
+        return entity;
+    }
+
+    public Long getSolveAttemptId() {
+        return solveAttemptId;
+    }
+
+    public ProblemAnswerFormat getAnswerFormat() {
+        return answerFormat;
+    }
+
+    public Integer getChoiceSequence() {
+        return choiceSequence;
+    }
+
+    public String getSubjectiveAnswer() {
+        return subjectiveAnswer;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/SolveAttemptJpaEntity.java
@@ -35,6 +35,10 @@ public class SolveAttemptJpaEntity {
     @Column(name = "is_correct")
     private Boolean correct;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_status", length = 20)
+    private com.project.quiz.domain.solving.AnswerStatus answerStatus;
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -47,6 +51,7 @@ public class SolveAttemptJpaEntity {
             Long problemId,
             AttemptStatus status,
             Boolean correct,
+            com.project.quiz.domain.solving.AnswerStatus answerStatus,
             LocalDateTime createdAt
     ) {
         SolveAttemptJpaEntity entity = new SolveAttemptJpaEntity();
@@ -55,11 +60,36 @@ public class SolveAttemptJpaEntity {
         entity.problemId = problemId;
         entity.status = status;
         entity.correct = correct;
+        entity.answerStatus = answerStatus;
         entity.createdAt = createdAt;
         return entity;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public Long getProblemId() {
         return problemId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getChapterId() {
+        return chapterId;
+    }
+
+    public AttemptStatus getStatus() {
+        return status;
+    }
+
+    public Boolean getCorrect() {
+        return correct;
+    }
+
+    public com.project.quiz.domain.solving.AnswerStatus getAnswerStatus() {
+        return answerStatus;
     }
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/mapper/ProblemMapper.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/mapper/ProblemMapper.java
@@ -1,25 +1,54 @@
 package com.project.quiz.infrastructure.persistence.mapper;
 
 import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerKey;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import com.project.quiz.domain.problem.ProblemChoice;
+import com.project.quiz.infrastructure.persistence.entity.ProblemAnswerKeyJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class ProblemMapper {
 
-    public Problem toDomain(ProblemJpaEntity entity, List<ProblemChoiceJpaEntity> choices) {
+    public Problem toDomain(
+            ProblemJpaEntity entity,
+            List<ProblemChoiceJpaEntity> choices,
+            List<ProblemAnswerKeyJpaEntity> answerKeys
+    ) {
         return new Problem(
                 entity.getId(),
                 entity.getChapterId(),
                 entity.getContent(),
+                entity.getAnswerFormat(),
                 entity.getType(),
                 choices.stream()
                         .map(choice -> new ProblemChoice(choice.getSequence(), choice.getContent()))
-                        .toList()
+                        .toList(),
+                toAnswerKey(entity.getAnswerFormat(), answerKeys),
+                entity.getExplanation()
         );
+    }
+
+    private ProblemAnswerKey toAnswerKey(
+            ProblemAnswerFormat answerFormat,
+            List<ProblemAnswerKeyJpaEntity> answerKeys
+    ) {
+        if (answerFormat == ProblemAnswerFormat.OBJECTIVE) {
+            Set<Integer> objectiveAnswers = answerKeys.stream()
+                    .map(ProblemAnswerKeyJpaEntity::getChoiceSequence)
+                    .collect(Collectors.toSet());
+            return new ProblemAnswerKey(objectiveAnswers, List.of());
+        }
+
+        List<String> subjectiveAnswers = answerKeys.stream()
+                .map(ProblemAnswerKeyJpaEntity::getSubjectiveAnswer)
+                .toList();
+        return new ProblemAnswerKey(Set.of(), subjectiveAnswers);
     }
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemAnswerKeyJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemAnswerKeyJpaRepository.java
@@ -1,0 +1,11 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ProblemAnswerKeyJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemAnswerKeyJpaRepository extends JpaRepository<ProblemAnswerKeyJpaEntity, Long> {
+
+    List<ProblemAnswerKeyJpaEntity> findAllByProblemIdOrderByIdAsc(Long problemId);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptAnswerJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptAnswerJpaRepository.java
@@ -1,0 +1,7 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolveAttemptAnswerJpaRepository extends JpaRepository<SolveAttemptAnswerJpaEntity, Long> {
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapter.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapter.java
@@ -3,19 +3,28 @@ package com.project.quiz.infrastructure.solving;
 import com.project.quiz.application.solving.port.out.CheckChapterExistsPort;
 import com.project.quiz.application.solving.port.out.CheckProblemInChapterPort;
 import com.project.quiz.application.solving.port.out.LoadChapterProblemsPort;
+import com.project.quiz.application.solving.port.out.LoadProblemDetailPort;
 import com.project.quiz.application.solving.port.out.LoadProblemCorrectRatePort;
 import com.project.quiz.application.solving.port.out.LoadUserChapterSolvingStatePort;
 import com.project.quiz.application.solving.port.out.SaveSkippedProblemPort;
+import com.project.quiz.application.solving.port.out.SaveSolvedAttemptPort;
 import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.solving.SubmittedAnswer;
 import com.project.quiz.domain.solving.UserChapterSolvingState;
 import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
 import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
+import com.project.quiz.infrastructure.persistence.entity.ProblemAnswerKeyJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
 import com.project.quiz.infrastructure.persistence.mapper.ProblemMapper;
+import com.project.quiz.infrastructure.persistence.repository.ProblemAnswerKeyJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptAnswerJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -34,14 +43,18 @@ public class RandomProblemPersistenceAdapter implements
         CheckChapterExistsPort,
         CheckProblemInChapterPort,
         LoadChapterProblemsPort,
+        LoadProblemDetailPort,
         LoadUserChapterSolvingStatePort,
         LoadProblemCorrectRatePort,
-        SaveSkippedProblemPort {
+        SaveSkippedProblemPort,
+        SaveSolvedAttemptPort {
 
     private final ChapterJpaRepository chapterJpaRepository;
     private final ProblemJpaRepository problemJpaRepository;
     private final ProblemChoiceJpaRepository problemChoiceJpaRepository;
+    private final ProblemAnswerKeyJpaRepository problemAnswerKeyJpaRepository;
     private final SolveAttemptJpaRepository solveAttemptJpaRepository;
+    private final SolveAttemptAnswerJpaRepository solveAttemptAnswerJpaRepository;
     private final ProblemMapper problemMapper;
 
     @Override
@@ -71,9 +84,20 @@ public class RandomProblemPersistenceAdapter implements
         return problems.stream()
                 .map(problem -> problemMapper.toDomain(
                         problem,
-                        choicesByProblemId.getOrDefault(problem.getId(), List.of())
+                        choicesByProblemId.getOrDefault(problem.getId(), List.of()),
+                        problemAnswerKeyJpaRepository.findAllByProblemIdOrderByIdAsc(problem.getId())
                 ))
                 .toList();
+    }
+
+    @Override
+    public Optional<Problem> loadById(Long problemId) {
+        return problemJpaRepository.findById(problemId)
+                .map(problem -> problemMapper.toDomain(
+                        problem,
+                        problemChoiceJpaRepository.findAllByProblemIdInOrderByProblemIdAscSequenceAsc(List.of(problemId)),
+                        problemAnswerKeyJpaRepository.findAllByProblemIdOrderByIdAsc(problemId)
+                ));
     }
 
     @Override
@@ -106,8 +130,44 @@ public class RandomProblemPersistenceAdapter implements
                         problemId,
                         AttemptStatus.SKIPPED,
                         null,
+                        null,
                         java.time.LocalDateTime.now()
                 )
+        );
+    }
+
+    @Override
+    @Transactional
+    public void saveSolvedAttempt(
+            Long userId,
+            Long chapterId,
+            Long problemId,
+            SubmittedAnswer answer,
+            AnswerStatus answerStatus
+    ) {
+        SolveAttemptJpaEntity solveAttempt = solveAttemptJpaRepository.save(
+                SolveAttemptJpaEntity.create(
+                        userId,
+                        chapterId,
+                        problemId,
+                        AttemptStatus.SOLVED,
+                        answerStatus == AnswerStatus.CORRECT,
+                        answerStatus,
+                        java.time.LocalDateTime.now()
+                )
+        );
+
+        if (answer.answerFormat() == ProblemAnswerFormat.OBJECTIVE) {
+            solveAttemptAnswerJpaRepository.saveAll(
+                    answer.selectedChoices().stream()
+                            .map(choice -> SolveAttemptAnswerJpaEntity.objective(solveAttempt.getId(), choice))
+                            .toList()
+            );
+            return;
+        }
+
+        solveAttemptAnswerJpaRepository.save(
+                SolveAttemptAnswerJpaEntity.subjective(solveAttempt.getId(), answer.subjectiveAnswer())
         );
     }
 }

--- a/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapterTest.java
+++ b/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/solving/RandomProblemPersistenceAdapterTest.java
@@ -1,19 +1,27 @@
 package com.project.quiz.infrastructure.solving;
 
 import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerKey;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.solving.SubmittedAnswer;
 import com.project.quiz.domain.solving.UserChapterSolvingState;
 import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
 import com.project.quiz.infrastructure.TestInfrastructureApplication;
 import com.project.quiz.infrastructure.persistence.entity.AttemptStatus;
 import com.project.quiz.infrastructure.persistence.entity.ChapterJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemAnswerKeyJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaEntity;
 import com.project.quiz.infrastructure.persistence.entity.SolveAttemptJpaEntity;
 import com.project.quiz.infrastructure.persistence.mapper.ProblemMapper;
 import com.project.quiz.infrastructure.persistence.repository.ChapterJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.ProblemAnswerKeyJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemJpaRepository;
+import com.project.quiz.infrastructure.persistence.repository.SolveAttemptAnswerJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.SolveAttemptJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,11 +56,19 @@ class RandomProblemPersistenceAdapterTest {
     private ProblemChoiceJpaRepository problemChoiceJpaRepository;
 
     @Autowired
+    private ProblemAnswerKeyJpaRepository problemAnswerKeyJpaRepository;
+
+    @Autowired
     private SolveAttemptJpaRepository solveAttemptJpaRepository;
+
+    @Autowired
+    private SolveAttemptAnswerJpaRepository solveAttemptAnswerJpaRepository;
 
     @BeforeEach
     void setUp() {
+        solveAttemptAnswerJpaRepository.deleteAll();
         solveAttemptJpaRepository.deleteAll();
+        problemAnswerKeyJpaRepository.deleteAll();
         problemChoiceJpaRepository.deleteAll();
         problemJpaRepository.deleteAll();
         chapterJpaRepository.deleteAll();
@@ -63,8 +79,8 @@ class RandomProblemPersistenceAdapterTest {
     void loadProblemsByChapterId() {
         chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
         problemJpaRepository.saveAll(List.of(
-                ProblemJpaEntity.create(100L, 1L, "problem-1", ProblemType.SINGLE_ANSWER),
-                ProblemJpaEntity.create(101L, 1L, "problem-2", ProblemType.MULTIPLE_ANSWER)
+                ProblemJpaEntity.create(100L, 1L, "problem-1", ProblemAnswerFormat.OBJECTIVE, ProblemType.SINGLE_ANSWER, "explanation-1"),
+                ProblemJpaEntity.create(101L, 1L, "problem-2", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER, "explanation-2")
         ));
         problemChoiceJpaRepository.saveAll(List.of(
                 ProblemChoiceJpaEntity.create(100L, 1, "p1-choice-1"),
@@ -72,14 +88,21 @@ class RandomProblemPersistenceAdapterTest {
                 ProblemChoiceJpaEntity.create(101L, 1, "p2-choice-1"),
                 ProblemChoiceJpaEntity.create(101L, 2, "p2-choice-2")
         ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(100L, 2),
+                ProblemAnswerKeyJpaEntity.objective(101L, 1),
+                ProblemAnswerKeyJpaEntity.objective(101L, 2)
+        ));
 
         List<Problem> problems = adapter.loadByChapterId(1L);
 
         assertThat(problems).hasSize(2);
         assertThat(problems.get(0).id()).isEqualTo(100L);
         assertThat(problems.get(0).chapterId()).isEqualTo(1L);
+        assertThat(problems.get(0).answerFormat()).isEqualTo(ProblemAnswerFormat.OBJECTIVE);
         assertThat(problems.get(0).choices()).extracting(choice -> choice.content())
                 .containsExactly("p1-choice-1", "p1-choice-2");
+        assertThat(problems.get(0).answerKey()).isEqualTo(new ProblemAnswerKey(Set.of(2), List.of()));
         assertThat(problems.get(1).type()).isEqualTo(ProblemType.MULTIPLE_ANSWER);
     }
 
@@ -87,9 +110,9 @@ class RandomProblemPersistenceAdapterTest {
     @DisplayName("사용자 챕터 풀이 상태를 solved 목록과 마지막 skipped 문제로 조회한다")
     void loadUserChapterSolvingState() {
         solveAttemptJpaRepository.saveAll(List.of(
-                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(3)),
-                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(2)),
-                SolveAttemptJpaEntity.create(1L, 1L, 102L, AttemptStatus.SKIPPED, null, LocalDateTime.now().minusMinutes(1))
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusMinutes(3)),
+                SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(1L, 1L, 102L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now().minusMinutes(1))
         ));
 
         UserChapterSolvingState state = adapter.load(1L, 1L);
@@ -104,10 +127,10 @@ class RandomProblemPersistenceAdapterTest {
     @DisplayName("문제 정답률 집계를 조회한다")
     void loadProblemCorrectRateSummary() {
         solveAttemptJpaRepository.saveAll(List.of(
-                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(3)),
-                SolveAttemptJpaEntity.create(2L, 1L, 100L, AttemptStatus.SOLVED, false, LocalDateTime.now().minusMinutes(2)),
-                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SOLVED, true, LocalDateTime.now().minusMinutes(1)),
-                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SKIPPED, null, LocalDateTime.now())
+                SolveAttemptJpaEntity.create(1L, 1L, 100L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusMinutes(3)),
+                SolveAttemptJpaEntity.create(2L, 1L, 100L, AttemptStatus.SOLVED, false, AnswerStatus.INCORRECT, LocalDateTime.now().minusMinutes(2)),
+                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusMinutes(1)),
+                SolveAttemptJpaEntity.create(3L, 1L, 100L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now())
         ));
 
         Optional<ProblemCorrectRateSummary> summary = adapter.loadByProblemId(100L);
@@ -124,5 +147,75 @@ class RandomProblemPersistenceAdapterTest {
 
         assertThat(adapter.existsById(1L)).isTrue();
         assertThat(adapter.existsById(99L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("문제 상세를 조회하면 정답 키와 해설을 함께 반환한다")
+    void loadProblemDetailById() {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.save(
+                ProblemJpaEntity.create(200L, 1L, "subjective-problem", ProblemAnswerFormat.SUBJECTIVE, ProblemType.SINGLE_ANSWER, "subjective-explanation")
+        );
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.subjective(200L, "싱글톤"),
+                ProblemAnswerKeyJpaEntity.subjective(200L, "singleton")
+        ));
+
+        Optional<Problem> loaded = adapter.loadById(200L);
+
+        assertThat(loaded).isPresent();
+        assertThat(loaded.get().answerFormat()).isEqualTo(ProblemAnswerFormat.SUBJECTIVE);
+        assertThat(loaded.get().explanation()).isEqualTo("subjective-explanation");
+        assertThat(loaded.get().answerKey().subjectiveAnswers()).containsExactly("싱글톤", "singleton");
+    }
+
+    @Test
+    @DisplayName("객관식 제출을 저장하면 풀이 이력과 선택 답안이 함께 저장된다")
+    void saveObjectiveSolvedAttempt() {
+        adapter.saveSolvedAttempt(
+                1L,
+                1L,
+                300L,
+                new SubmittedAnswer(ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null),
+                AnswerStatus.PARTIAL
+        );
+
+        List<SolveAttemptJpaEntity> attempts = solveAttemptJpaRepository.findAll();
+        List<SolveAttemptAnswerJpaEntity> answers = solveAttemptAnswerJpaRepository.findAll();
+
+        assertThat(attempts).hasSize(1);
+        assertThat(attempts.get(0).getUserId()).isEqualTo(1L);
+        assertThat(attempts.get(0).getChapterId()).isEqualTo(1L);
+        assertThat(attempts.get(0).getProblemId()).isEqualTo(300L);
+        assertThat(attempts.get(0).getStatus()).isEqualTo(AttemptStatus.SOLVED);
+        assertThat(attempts.get(0).getCorrect()).isFalse();
+        assertThat(attempts.get(0).getAnswerStatus()).isEqualTo(AnswerStatus.PARTIAL);
+        assertThat(answers).hasSize(2);
+        assertThat(answers).extracting(SolveAttemptAnswerJpaEntity::getAnswerFormat)
+                .containsOnly(ProblemAnswerFormat.OBJECTIVE);
+        assertThat(answers).extracting(SolveAttemptAnswerJpaEntity::getChoiceSequence)
+                .containsExactlyInAnyOrder(1, 3);
+    }
+
+    @Test
+    @DisplayName("주관식 제출을 저장하면 텍스트 답안이 함께 저장된다")
+    void saveSubjectiveSolvedAttempt() {
+        adapter.saveSolvedAttempt(
+                2L,
+                2L,
+                400L,
+                new SubmittedAnswer(ProblemAnswerFormat.SUBJECTIVE, null, "싱글톤"),
+                AnswerStatus.CORRECT
+        );
+
+        List<SolveAttemptJpaEntity> attempts = solveAttemptJpaRepository.findAll();
+        List<SolveAttemptAnswerJpaEntity> answers = solveAttemptAnswerJpaRepository.findAll();
+
+        assertThat(attempts).hasSize(1);
+        assertThat(attempts.get(0).getCorrect()).isTrue();
+        assertThat(attempts.get(0).getAnswerStatus()).isEqualTo(AnswerStatus.CORRECT);
+        assertThat(answers).hasSize(1);
+        assertThat(answers.get(0).getAnswerFormat()).isEqualTo(ProblemAnswerFormat.SUBJECTIVE);
+        assertThat(answers.get(0).getSubjectiveAnswer()).isEqualTo("싱글톤");
     }
 }


### PR DESCRIPTION
## 요약
  - 문제 제출 API를 구현했습니다.
  - 객관식/주관식 답안 제출을 지원하고, 제출 즉시 채점 결과와 해설을 반환하도록 구성했습니다.
  - 제출 이력을 DB에 저장하고, answerType 기반 요청 validation도 추가했습니다.

  ## 변경 사항
  - domain
    - `ProblemAnswerFormat`, `ProblemAnswerKey`, `SubmittedAnswer`, `GradingResult`, `AnswerStatus` 추가
    - `Problem`에 객관식/주관식 채점 로직 추가
  - application
    - `SubmitProblemAnswerUseCase`, command, result 추가
    - `SubmitProblemAnswerService` 구현
    - 문제 상세 조회 / 제출 저장 port 추가
    - `ProblemAnswerTypeMismatchException` 추가
  - api
    - `POST /api/problems/submit` controller 추가
    - request / response DTO 추가
    - answerType 기반 커스텀 validation 추가
    - 예외 응답 처리 추가
  - infrastructure
    - 문제 정답 키 / 제출 답안 저장용 JPA entity 및 repository 추가
    - persistence adapter에 문제 상세 조회 / 제출 저장 기능 추가
    - MySQL init SQL 확장
  - test
    - application unit test 추가
    - API `@WebMvcTest` 추가
    - infrastructure integration test 추가
    - bootstrap end-to-end test 추가

  ## 설계 의도
  문제 제출은 단순 조회가 아니라 채점 정책과 제출 이력 저장이 함께 일어나는 유스케이스이므로,
  application service를 중심으로 트랜잭션 경계를 두고 구현했습니다.

  도메인에서는 `Problem`이 채점 규칙을 담당하고,
  application은 유스케이스 조합,
  api는 요청/응답 및 validation,
  infrastructure는 문제 상세 조회와 제출 저장을 담당하도록 역할을 분리했습니다.

  영속성 모델은 기존 방향과 동일하게 JPA 연관관계를 최소화하고 FK id 기반으로 유지했습니다.

  ## 검증
  실행한 명령:
  ```bash
  ./gradlew :quiz-application:test
  ./gradlew :quiz-api:test
  ./gradlew :quiz-infrastructure:test
  ./gradlew :quiz-bootstrap:test
  ./gradlew test

  ## 영향 범위

  - quiz-domain
  - quiz-application
  - quiz-api
  - quiz-infrastructure
  - docker/mysql/init/01-schema-and-seed.sql