### PR TITLE
[Refactor] problem 패키지 기준으로 ProblemController 및 API 테스트 통합

### DIFF
--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemRequest.java
@@ -1,0 +1,19 @@
+package com.project.quiz.api.problem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "랜덤 문제 조회 요청")
+public record GetRandomProblemRequest(
+        @Schema(description = "단원 ID", example = "1")
+        @NotNull(message = "chapterId is required")
+        @Positive(message = "chapterId must be positive")
+        Long chapterId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemResponse.java
@@ -1,0 +1,22 @@
+package com.project.quiz.api.problem;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "랜덤 문제 조회 응답")
+public record GetRandomProblemResponse(
+        @Schema(description = "문제 ID", example = "1")
+        Long problemId,
+
+        @Schema(description = "문제 내용", example = "문제 설명")
+        String content,
+
+        @ArraySchema(schema = @Schema(description = "객관식 선택지 목록", example = "지문1"))
+        List<String> choices,
+
+        @Schema(description = "문제 정답률. 30명 미만이 풀었으면 null 입니다.", example = "67", nullable = true)
+        Integer answerCorrectRate
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
@@ -1,0 +1,179 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.api.common.ErrorResponse;
+import com.project.quiz.application.solving.model.GetRandomProblemCommand;
+import com.project.quiz.application.solving.model.GetRandomProblemResult;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailCommand;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailResult;
+import com.project.quiz.application.solving.model.SkipProblemCommand;
+import com.project.quiz.application.solving.model.SubmitProblemAnswerCommand;
+import com.project.quiz.application.solving.model.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.service.GetRandomProblemService;
+import com.project.quiz.application.solving.service.GetSolvedProblemDetailService;
+import com.project.quiz.application.solving.service.SkipProblemService;
+import com.project.quiz.application.solving.service.SubmitProblemAnswerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "단원별 문제 풀이", description = "단원별 랜덤 문제 조회와 풀이 관련 엔드포인트")
+@RestController
+@RequestMapping("/api/problems")
+@RequiredArgsConstructor
+public class ProblemController {
+
+    private final GetRandomProblemService getRandomProblemService;
+    private final GetSolvedProblemDetailService getSolvedProblemDetailService;
+    private final SkipProblemService skipProblemService;
+    private final SubmitProblemAnswerService submitProblemAnswerService;
+
+    @Operation(
+            summary = "랜덤 미풀이 문제 조회",
+            description = "선택한 단원에서 이미 푼 문제와 직전에 건너뛴 문제를 제외하고 랜덤 문제 1개를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "랜덤 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 단원을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "해당 단원에 더 이상 출제 가능한 문제가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/random")
+    public ResponseEntity<GetRandomProblemResponse> getRandomProblem(@Valid @RequestBody GetRandomProblemRequest request) {
+        GetRandomProblemResult result = getRandomProblemService.getRandomProblem(
+                new GetRandomProblemCommand(request.userId(), request.chapterId())
+        );
+        return ResponseEntity.ok(toRandomProblemResponse(result));
+    }
+
+    @Operation(
+            summary = "문제 넘기기",
+            description = "현재 문제를 건너뛴 뒤 같은 단원에서 다음 랜덤 문제 1개를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문제를 건너뛰고 다음 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "해당 단원 또는 문제가 존재하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "건너뛴 이후 더 이상 출제 가능한 문제가 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/skip")
+    public ResponseEntity<GetRandomProblemResponse> skipProblem(@Valid @RequestBody SkipProblemRequest request) {
+        GetRandomProblemResult result = skipProblemService.skipProblem(
+                new SkipProblemCommand(request.userId(), request.chapterId(), request.problemId())
+        );
+        return ResponseEntity.ok(toRandomProblemResponse(result));
+    }
+
+    @Operation(summary = "풀었던 문제 상세 조회", description = "사용자가 이전에 풀었던 문제의 채점 결과, 해설, 정답, 제출 답안을 상세 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "풀었던 문제 상세가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "문제 또는 풀이 이력을 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/detail")
+    public ResponseEntity<GetSolvedProblemDetailResponse> getSolvedProblemDetail(@Valid @RequestBody GetSolvedProblemDetailRequest request) {
+        GetSolvedProblemDetailResult result = getSolvedProblemDetailService.getDetail(
+                new GetSolvedProblemDetailCommand(request.userId(), request.problemId())
+        );
+
+        return ResponseEntity.ok(new GetSolvedProblemDetailResponse(
+                result.problemId(),
+                result.answerType(),
+                result.answerStatus(),
+                result.explanation(),
+                result.problemAnswers(),
+                result.userAnswers(),
+                result.answerCorrectRate()
+        ));
+    }
+
+    @Operation(summary = "문제 제출", description = "객관식 또는 주관식 답안을 제출하고 즉시 채점 결과와 해설을 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문제 제출이 정상적으로 처리되었습니다."),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청입니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "문제를 찾을 수 없습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "문제의 답안 형식과 제출 형식이 일치하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping("/submit")
+    public ResponseEntity<SubmitProblemAnswerResponse> submit(@Valid @RequestBody SubmitProblemAnswerRequest request) {
+        SubmitProblemAnswerResult result = submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(
+                        request.problemId(),
+                        request.userId(),
+                        request.answerType(),
+                        request.selectedChoices(),
+                        request.subjectiveAnswer()
+                )
+        );
+
+        return ResponseEntity.ok(new SubmitProblemAnswerResponse(
+                result.problemId(),
+                result.answerType(),
+                result.answerStatus(),
+                result.explanation(),
+                result.problemAnswers()
+        ));
+    }
+
+    private GetRandomProblemResponse toRandomProblemResponse(GetRandomProblemResult result) {
+        return new GetRandomProblemResponse(
+                result.problemId(),
+                result.content(),
+                result.choices().stream().map(choice -> choice.content()).toList(),
+                result.answerCorrectRate()
+        );
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SkipProblemRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SkipProblemRequest.java
@@ -1,0 +1,24 @@
+package com.project.quiz.api.problem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "문제 넘기기 요청")
+public record SkipProblemRequest(
+        @Schema(description = "단원 ID", example = "1")
+        @NotNull(message = "chapterId is required")
+        @Positive(message = "chapterId must be positive")
+        Long chapterId,
+
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId,
+
+        @Schema(description = "건너뛸 현재 문제 ID", example = "1001")
+        @NotNull(message = "problemId is required")
+        @Positive(message = "problemId must be positive")
+        Long problemId
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequest.java
@@ -1,4 +1,4 @@
-package com.project.quiz.api.solving;
+package com.project.quiz.api.problem;
 
 import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import io.swagger.v3.oas.annotations.media.ArraySchema;

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidator.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidator.java
@@ -1,0 +1,36 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class SubmitProblemAnswerRequestValidator implements ConstraintValidator<ValidSubmitProblemAnswerRequest, SubmitProblemAnswerRequest> {
+
+    @Override
+    public boolean isValid(SubmitProblemAnswerRequest value, ConstraintValidatorContext context) {
+        if (value == null || value.answerType() == null) {
+            return true;
+        }
+
+        context.disableDefaultConstraintViolation();
+
+        if (value.answerType() == ProblemAnswerFormat.OBJECTIVE) {
+            if (value.selectedChoices() == null || value.selectedChoices().isEmpty()) {
+                context.buildConstraintViolationWithTemplate("selectedChoices must not be empty for OBJECTIVE answerType")
+                        .addPropertyNode("selectedChoices")
+                        .addConstraintViolation();
+                return false;
+            }
+            return true;
+        }
+
+        if (value.subjectiveAnswer() == null || value.subjectiveAnswer().isBlank()) {
+            context.buildConstraintViolationWithTemplate("subjectiveAnswer must not be blank for SUBJECTIVE answerType")
+                    .addPropertyNode("subjectiveAnswer")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerResponse.java
@@ -1,0 +1,23 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "문제 제출 응답")
+public record SubmitProblemAnswerResponse(
+        @Schema(description = "문제 ID", example = "1001")
+        Long problemId,
+        @Schema(description = "답안 형식", example = "OBJECTIVE")
+        ProblemAnswerFormat answerType,
+        @Schema(description = "채점 결과", example = "PARTIAL")
+        AnswerStatus answerStatus,
+        @Schema(description = "문제 해설", example = "정답은 boolean 입니다.")
+        String explanation,
+        @ArraySchema(schema = @Schema(description = "정답 목록", example = "3"))
+        List<String> problemAnswers
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/ValidSubmitProblemAnswerRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/ValidSubmitProblemAnswerRequest.java
@@ -1,0 +1,21 @@
+package com.project.quiz.api.problem;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SubmitProblemAnswerRequestValidator.class)
+public @interface ValidSubmitProblemAnswerRequest {
+
+    String message() default "invalid submit problem answer request";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
@@ -1,0 +1,283 @@
+package com.project.quiz.api.problem;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.quiz.api.TestApiApplication;
+import com.project.quiz.api.common.GlobalExceptionHandler;
+import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.NoAvailableProblemException;
+import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.exception.SolvedProblemNotFoundException;
+import com.project.quiz.application.solving.model.GetRandomProblemChoiceResult;
+import com.project.quiz.application.solving.model.GetRandomProblemResult;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailResult;
+import com.project.quiz.application.solving.model.SubmitProblemAnswerResult;
+import com.project.quiz.application.solving.service.GetRandomProblemService;
+import com.project.quiz.application.solving.service.GetSolvedProblemDetailService;
+import com.project.quiz.application.solving.service.SkipProblemService;
+import com.project.quiz.application.solving.service.SubmitProblemAnswerService;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProblemController.class)
+@ContextConfiguration(classes = {
+        TestApiApplication.class,
+        ProblemController.class,
+        GlobalExceptionHandler.class
+})
+class ProblemControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GetRandomProblemService getRandomProblemService;
+
+    @MockBean
+    private GetSolvedProblemDetailService getSolvedProblemDetailService;
+
+    @MockBean
+    private SkipProblemService skipProblemService;
+
+    @MockBean
+    private SubmitProblemAnswerService submitProblemAnswerService;
+
+    @Test
+    @DisplayName("랜덤 문제를 정상 반환한다")
+    void returnRandomProblem() throws Exception {
+        GetRandomProblemResult result = new GetRandomProblemResult(
+                1L,
+                "문제 설명",
+                List.of(
+                        new GetRandomProblemChoiceResult(1, "보기 1"),
+                        new GetRandomProblemChoiceResult(2, "보기 2")
+                ),
+                67
+        );
+
+        when(getRandomProblemService.getRandomProblem(any())).thenReturn(result);
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(1))
+                .andExpect(jsonPath("$.content").value("문제 설명"))
+                .andExpect(jsonPath("$.choices[0]").value("보기 1"))
+                .andExpect(jsonPath("$.answerCorrectRate").value(67));
+
+        verify(getRandomProblemService).getRandomProblem(any());
+    }
+
+    @Test
+    @DisplayName("랜덤 문제 요청 검증 실패면 400을 반환한다")
+    void returnBadRequestWhenRandomRequestInvalid() throws Exception {
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(null, 1L))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("랜덤 문제 요청에서 챕터가 없으면 404를 반환한다")
+    void returnNotFoundWhenChapterMissing() throws Exception {
+        when(getRandomProblemService.getRandomProblem(any()))
+                .thenThrow(new ChapterNotFoundException(999L));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 999L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CHAPTER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("출제 가능한 문제가 없으면 409를 반환한다")
+    void returnConflictWhenNoAvailableProblemExists() throws Exception {
+        when(getRandomProblemService.getRandomProblem(any()))
+                .thenThrow(new NoAvailableProblemException(1L, 1L));
+
+        mockMvc.perform(post("/api/problems/random")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"));
+    }
+
+    @Test
+    @DisplayName("문제 넘기기 정상 응답을 반환한다")
+    void returnNextProblemWhenSkipSucceeds() throws Exception {
+        when(skipProblemService.skipProblem(any()))
+                .thenReturn(new GetRandomProblemResult(
+                        101L,
+                        "다음 문제",
+                        List.of(
+                                new GetRandomProblemChoiceResult(1, "보기1"),
+                                new GetRandomProblemChoiceResult(2, "보기2")
+                        ),
+                        null
+                ));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(101))
+                .andExpect(jsonPath("$.content").value("다음 문제"));
+    }
+
+    @Test
+    @DisplayName("문제 넘기기에서 잘못된 요청이면 400을 반환한다")
+    void returnBadRequestWhenSkipRequestInvalid() throws Exception {
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, null, 100L))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("문제 넘기기에서 문제가 없으면 404를 반환한다")
+    void returnNotFoundWhenProblemMissingInSkip() throws Exception {
+        when(skipProblemService.skipProblem(any()))
+                .thenThrow(new ProblemNotFoundInChapterException(1L, 100L));
+
+        mockMvc.perform(post("/api/problems/skip")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+    }
+
+    @Test
+    @DisplayName("풀었던 문제 상세를 정상 반환한다")
+    void returnSolvedProblemDetail() throws Exception {
+        when(getSolvedProblemDetailService.getDetail(any()))
+                .thenReturn(new GetSolvedProblemDetailResult(
+                        3L,
+                        ProblemAnswerFormat.OBJECTIVE,
+                        AnswerStatus.PARTIAL,
+                        "해설",
+                        List.of("1", "2"),
+                        List.of("1", "3"),
+                        67
+                ));
+
+        mockMvc.perform(post("/api/problems/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(3))
+                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.userAnswers[1]").value("3"))
+                .andExpect(jsonPath("$.answerCorrectRate").value(67));
+    }
+
+    @Test
+    @DisplayName("풀었던 문제 상세 요청이 잘못되면 400을 반환한다")
+    void returnBadRequestWhenDetailRequestInvalid() throws Exception {
+        mockMvc.perform(post("/api/problems/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    @DisplayName("풀었던 문제 상세 이력이 없으면 404를 반환한다")
+    void returnNotFoundWhenSolvedProblemDetailMissing() throws Exception {
+        when(getSolvedProblemDetailService.getDetail(any()))
+                .thenThrow(new SolvedProblemNotFoundException(1L, 3L));
+
+        mockMvc.perform(post("/api/problems/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SOLVED_PROBLEM_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("문제 제출 정상 응답을 반환한다")
+    void returnGradingResultWhenSubmitSucceeds() throws Exception {
+        when(submitProblemAnswerService.submit(any()))
+                .thenReturn(new SubmitProblemAnswerResult(1001L, ProblemAnswerFormat.OBJECTIVE, AnswerStatus.PARTIAL, "해설", List.of("1", "2")));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(1001))
+                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.problemAnswers[0]").value("1"));
+    }
+
+    @Test
+    @DisplayName("문제 제출에서 문제가 없으면 404를 반환한다")
+    void returnNotFoundWhenProblemMissingInSubmit() throws Exception {
+        when(submitProblemAnswerService.submit(any()))
+                .thenThrow(new ProblemNotFoundInChapterException(null, 999L));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(999L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+    }
+
+    @Test
+    @DisplayName("문제 제출에서 답안 형식이 맞지 않으면 409를 반환한다")
+    void returnConflictWhenAnswerTypeMismatch() throws Exception {
+        when(submitProblemAnswerService.submit(any()))
+                .thenThrow(new ProblemAnswerTypeMismatchException(1001L));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("PROBLEM_ANSWER_TYPE_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("객관식 제출에서 선택지가 비어 있으면 400을 반환한다")
+    void returnBadRequestWhenObjectiveChoicesMissing() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(), null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must not be empty for OBJECTIVE answerType"));
+    }
+
+    @Test
+    @DisplayName("주관식 제출에서 답안이 비어 있으면 400을 반환한다")
+    void returnBadRequestWhenSubjectiveAnswerMissing() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, null, "   "))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must not be blank for SUBJECTIVE answerType"));
+    }
+}


### PR DESCRIPTION

  ## 요약
  - quiz-api 패키지를 solving -> problem 기준으로 정리했습니다.
  - random/skip/submit 엔드포인트를 ProblemController 하나로 통합했습니다.
  - 테스트도 ProblemControllerTest 하나로 정리했습니다.

  ## 변경 사항
  - request/response/validator를 problem 패키지로 이동
  - ProblemController 추가
  - 기존 개별 controller 제거
  - ProblemControllerTest 추가 및 기존 테스트 제거

  ## 설계 의도
  현재 API는 모두 /api/problems 리소스를 다루고 있어 분리보다 통합이 더 읽기 쉽다고 판단했습니다.

  ## 검증
  ```bash
  ./gradlew :quiz-api:test
  ./gradlew test