### PR TITLE
[Feat] 풀었던 문제 상세 조회 API 구현

### DIFF
--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.project.quiz.application.solving.exception.ChapterNotFoundException;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
 import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.exception.SolvedProblemNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -32,6 +33,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleProblemNotFoundInChapter(ProblemNotFoundInChapterException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse("PROBLEM_NOT_FOUND_IN_CHAPTER", exception.getMessage()));
+    }
+
+    @ExceptionHandler(SolvedProblemNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleSolvedProblemNotFound(SolvedProblemNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("SOLVED_PROBLEM_NOT_FOUND", exception.getMessage()));
     }
 
     @ExceptionHandler(ProblemAnswerTypeMismatchException.class)

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailRequest.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailRequest.java
@@ -1,0 +1,19 @@
+package com.project.quiz.api.problem;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "풀었던 문제 상세 조회 요청")
+public record GetSolvedProblemDetailRequest(
+        @Schema(description = "사용자 ID", example = "1")
+        @NotNull(message = "userId is required")
+        @Positive(message = "userId must be positive")
+        Long userId,
+
+        @Schema(description = "문제 ID", example = "1003")
+        @NotNull(message = "problemId is required")
+        @Positive(message = "problemId must be positive")
+        Long problemId
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailResponse.java
@@ -1,0 +1,27 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "풀었던 문제 상세 조회 응답")
+public record GetSolvedProblemDetailResponse(
+        @Schema(description = "문제 ID", example = "3")
+        Long problemId,
+        @Schema(description = "답안 형식", example = "OBJECTIVE")
+        ProblemAnswerFormat answerType,
+        @Schema(description = "채점 결과", example = "CORRECT")
+        AnswerStatus answerStatus,
+        @Schema(description = "문제 해설", example = "정답은 1번과 2번입니다.")
+        String explanation,
+        @ArraySchema(schema = @Schema(description = "문제 정답", example = "1"))
+        List<String> problemAnswers,
+        @ArraySchema(schema = @Schema(description = "사용자 제출 답안", example = "3"))
+        List<String> userAnswers,
+        @Schema(description = "문제 정답률", example = "67")
+        Integer answerCorrectRate
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/SolvedProblemNotFoundException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/SolvedProblemNotFoundException.java
@@ -1,0 +1,8 @@
+package com.project.quiz.application.solving.exception;
+
+public class SolvedProblemNotFoundException extends RuntimeException {
+
+    public SolvedProblemNotFoundException(Long userId, Long problemId) {
+        super("Solved problem not found. userId=%d, problemId=%d".formatted(userId, problemId));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/model/GetSolvedProblemDetailCommand.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/model/GetSolvedProblemDetailCommand.java
@@ -1,0 +1,7 @@
+package com.project.quiz.application.solving.model;
+
+public record GetSolvedProblemDetailCommand(
+        Long userId,
+        Long problemId
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/model/GetSolvedProblemDetailResult.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/model/GetSolvedProblemDetailResult.java
@@ -1,0 +1,17 @@
+package com.project.quiz.application.solving.model;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.AnswerStatus;
+
+import java.util.List;
+
+public record GetSolvedProblemDetailResult(
+        Long problemId,
+        ProblemAnswerFormat answerType,
+        AnswerStatus answerStatus,
+        String explanation,
+        List<String> problemAnswers,
+        List<String> userAnswers,
+        Integer answerCorrectRate
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetSolvedProblemDetailService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetSolvedProblemDetailService.java
@@ -1,0 +1,54 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
+import com.project.quiz.application.solving.exception.SolvedProblemNotFoundException;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailCommand;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailResult;
+import com.project.quiz.application.solving.repository.ProblemRepository;
+import com.project.quiz.application.solving.repository.SolveAttemptRepository;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.solving.SolvedProblem;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class GetSolvedProblemDetailService {
+
+    private final ProblemRepository problemRepository;
+    private final SolveAttemptRepository solveAttemptRepository;
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+
+    public GetSolvedProblemDetailResult getDetail(GetSolvedProblemDetailCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+
+        Problem problem = problemRepository.findById(command.problemId())
+                .orElseThrow(() -> new ProblemNotFoundInChapterException(null, command.problemId()));
+
+        SolvedProblem solvedProblem = solveAttemptRepository.findLatestSolvedProblem(command.userId(), command.problemId())
+                .orElseThrow(() -> new SolvedProblemNotFoundException(command.userId(), command.problemId()));
+
+        Integer correctRate = solveAttemptRepository.findCorrectRateByProblemId(command.problemId())
+                .map(problemCorrectRatePolicy::calculateExposedRate)
+                .orElse(null);
+
+        return new GetSolvedProblemDetailResult(
+                problem.id(),
+                problem.answerFormat(),
+                solvedProblem.answerStatus(),
+                problem.explanation(),
+                toAnswers(problem.answerFormat(), problem.answerKey().objectiveAnswers().stream().sorted().map(String::valueOf).toList(), problem.answerKey().subjectiveAnswers()),
+                toAnswers(problem.answerFormat(), solvedProblem.userAnswer().selectedChoices() == null ? List.of() : solvedProblem.userAnswer().selectedChoices().stream().map(String::valueOf).toList(), solvedProblem.userAnswer().subjectiveAnswer() == null ? List.of() : List.of(solvedProblem.userAnswer().subjectiveAnswer())),
+                correctRate
+        );
+    }
+
+    private List<String> toAnswers(ProblemAnswerFormat answerFormat, List<String> objectiveAnswers, List<String> subjectiveAnswers) {
+        return answerFormat == ProblemAnswerFormat.OBJECTIVE ? objectiveAnswers : subjectiveAnswers;
+    }
+}

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetSolvedProblemDetailServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/GetSolvedProblemDetailServiceTest.java
@@ -1,0 +1,99 @@
+package com.project.quiz.application.solving.service;
+
+import com.project.quiz.application.solving.exception.SolvedProblemNotFoundException;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailCommand;
+import com.project.quiz.application.solving.model.GetSolvedProblemDetailResult;
+import com.project.quiz.application.solving.repository.ProblemRepository;
+import com.project.quiz.application.solving.repository.SolveAttemptRepository;
+import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import com.project.quiz.domain.problem.ProblemAnswerKey;
+import com.project.quiz.domain.problem.ProblemType;
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.solving.SolvedProblem;
+import com.project.quiz.domain.solving.SubmittedAnswer;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetSolvedProblemDetailServiceTest {
+
+    @Mock
+    private ProblemRepository problemRepository;
+
+    @Mock
+    private SolveAttemptRepository solveAttemptRepository;
+
+    private GetSolvedProblemDetailService getSolvedProblemDetailService;
+
+    @BeforeEach
+    void setUp() {
+        getSolvedProblemDetailService = new GetSolvedProblemDetailService(problemRepository, solveAttemptRepository);
+    }
+
+    @Test
+    void returnSolvedProblemDetail() {
+        Problem problem = new Problem(
+                3L,
+                1L,
+                "problem",
+                ProblemAnswerFormat.OBJECTIVE,
+                ProblemType.MULTIPLE_ANSWER,
+                List.of(),
+                new ProblemAnswerKey(Set.of(1, 2), List.of()),
+                "해설"
+        );
+
+        when(problemRepository.findById(3L)).thenReturn(Optional.of(problem));
+        when(solveAttemptRepository.findLatestSolvedProblem(1L, 3L))
+                .thenReturn(Optional.of(new SolvedProblem(
+                        3L,
+                        AnswerStatus.PARTIAL,
+                        new SubmittedAnswer(ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null)
+                )));
+        when(solveAttemptRepository.findCorrectRateByProblemId(3L))
+                .thenReturn(Optional.of(new ProblemCorrectRateSummary(30L, 20L)));
+
+        GetSolvedProblemDetailResult result = getSolvedProblemDetailService.getDetail(
+                new GetSolvedProblemDetailCommand(1L, 3L)
+        );
+
+        assertThat(result.problemId()).isEqualTo(3L);
+        assertThat(result.answerStatus()).isEqualTo(AnswerStatus.PARTIAL);
+        assertThat(result.problemAnswers()).containsExactly("1", "2");
+        assertThat(result.userAnswers()).containsExactly("1", "3");
+        assertThat(result.answerCorrectRate()).isEqualTo(67);
+    }
+
+    @Test
+    void throwWhenSolvedProblemMissing() {
+        Problem problem = new Problem(
+                3L,
+                1L,
+                "problem",
+                ProblemAnswerFormat.OBJECTIVE,
+                ProblemType.SINGLE_ANSWER,
+                List.of(),
+                new ProblemAnswerKey(Set.of(1), List.of()),
+                "해설"
+        );
+
+        when(problemRepository.findById(3L)).thenReturn(Optional.of(problem));
+        when(solveAttemptRepository.findLatestSolvedProblem(1L, 3L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getSolvedProblemDetailService.getDetail(new GetSolvedProblemDetailCommand(1L, 3L)))
+                .isInstanceOf(SolvedProblemNotFoundException.class);
+    }
+}

--- a/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
+++ b/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
@@ -218,4 +218,53 @@ class GetRandomProblemEndToEndTest {
                 .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
                 .andExpect(jsonPath("$.problemAnswers[1]").value("2"));
     }
+
+    @Test
+    @DisplayName("풀었던 문제 상세를 조회한다")
+    void getSolvedProblemDetailEndToEnd() throws Exception {
+        chapterJpaRepository.save(ChapterJpaEntity.create(1L, "chapter-1"));
+        problemJpaRepository.save(ProblemJpaEntity.create(
+                4001L, 1L, "정답을 모두 고르세요", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER, "정답은 1번과 2번입니다."
+        ));
+        problemChoiceJpaRepository.saveAll(List.of(
+                ProblemChoiceJpaEntity.create(4001L, 1, "선택지 1"),
+                ProblemChoiceJpaEntity.create(4001L, 2, "선택지 2"),
+                ProblemChoiceJpaEntity.create(4001L, 3, "선택지 3"),
+                ProblemChoiceJpaEntity.create(4001L, 4, "선택지 4"),
+                ProblemChoiceJpaEntity.create(4001L, 5, "선택지 5")
+        ));
+        problemAnswerKeyJpaRepository.saveAll(List.of(
+                ProblemAnswerKeyJpaEntity.objective(4001L, 1),
+                ProblemAnswerKeyJpaEntity.objective(4001L, 2)
+        ));
+
+        SolveAttemptJpaEntity solvedAttempt = solveAttemptJpaRepository.save(
+                SolveAttemptJpaEntity.create(1L, 1L, 4001L, AttemptStatus.SOLVED, false, AnswerStatus.PARTIAL, LocalDateTime.now())
+        );
+        solveAttemptAnswerJpaRepository.saveAll(List.of(
+                com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaEntity.objective(solvedAttempt.getId(), 1),
+                com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaEntity.objective(solvedAttempt.getId(), 3)
+        ));
+
+        solveAttemptJpaRepository.saveAll(List.of(
+                SolveAttemptJpaEntity.create(2L, 1L, 4001L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusSeconds(30)),
+                SolveAttemptJpaEntity.create(3L, 1L, 4001L, AttemptStatus.SOLVED, false, AnswerStatus.INCORRECT, LocalDateTime.now().minusSeconds(20)),
+                SolveAttemptJpaEntity.create(4L, 1L, 4001L, AttemptStatus.SOLVED, true, AnswerStatus.CORRECT, LocalDateTime.now().minusSeconds(10))
+        ));
+
+        mockMvc.perform(post("/api/problems/detail")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "userId", 1L,
+                                "problemId", 4001L
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.problemId").value(4001))
+                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.problemAnswers[1]").value("2"))
+                .andExpect(jsonPath("$.userAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.userAnswers[1]").value("3"))
+                .andExpect(jsonPath("$.answerCorrectRate").value(nullValue()));
+    }
 }

--- a/quiz-domain/src/main/java/com/project/quiz/domain/solving/SolvedProblem.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/solving/SolvedProblem.java
@@ -1,0 +1,8 @@
+package com.project.quiz.domain.solving;
+
+public record SolvedProblem(
+        Long problemId,
+        AnswerStatus answerStatus,
+        SubmittedAnswer userAnswer
+) {
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptAnswerJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptAnswerJpaRepository.java
@@ -4,4 +4,6 @@ import com.project.quiz.infrastructure.persistence.entity.SolveAttemptAnswerJpaE
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SolveAttemptAnswerJpaRepository extends JpaRepository<SolveAttemptAnswerJpaEntity, Long> {
+
+    java.util.List<SolveAttemptAnswerJpaEntity> findAllBySolveAttemptIdOrderByIdAsc(Long solveAttemptId);
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/SolveAttemptJpaRepository.java
@@ -26,6 +26,12 @@ public interface SolveAttemptJpaRepository extends JpaRepository<SolveAttemptJpa
             AttemptStatus status
     );
 
+    Optional<SolveAttemptJpaEntity> findTopByUserIdAndProblemIdAndStatusOrderByIdDesc(
+            Long userId,
+            Long problemId,
+            AttemptStatus status
+    );
+
     @Query("""
             select
                 count(distinct sa.userId) as solvedUserCount,


### PR DESCRIPTION
## 요약
  - 사용자가 이전에 풀었던 문제의 상세 정보를 조회하는 API를 추가했습니다.
  - 최신 SOLVED 이력을 기준으로 정답/제출답안/해설/정답률을 함께 반환합니다.

  ## 변경 사항
  - SolvedProblem 도메인 모델 추가
  - GetSolvedProblemDetailService, command, result 추가
  - SolveAttemptRepository에 최신 풀이 이력 조회 추가
  - ProblemController에 POST /api/problems/detail 추가
  - SolvedProblemNotFoundException 및 테스트 추가

  ## 설계 의도
  현재 구조를 유지하면서도, 문제 정보와 사용자 풀이 이력을 application service에서 조합하도록 설계했습니다.

  ## 검증
  ```bash
  ./gradlew :quiz-application:test
  ./gradlew :quiz-api:test
  ./gradlew :quiz-infrastructure:test
  ./gradlew :quiz-bootstrap:test
  ./gradlew test