### PR TITLE
[Feat] 정답률 통계 구조 개선 및 Redis 캐시/배치 적용

### DIFF
--- a/docker/mysql/init/01-schema-and-seed.sql
+++ b/docker/mysql/init/01-schema-and-seed.sql
@@ -42,6 +42,30 @@ CREATE TABLE IF NOT EXISTS solve_attempts (
     CONSTRAINT fk_solve_attempts_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
 );
 
+CREATE TABLE IF NOT EXISTS problem_statistics (
+    problem_id BIGINT NOT NULL PRIMARY KEY,
+    solved_user_count BIGINT NOT NULL,
+    correct_user_count BIGINT NOT NULL,
+    correct_rate INT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT fk_problem_statistics_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
+);
+
+CREATE TABLE IF NOT EXISTS problem_user_statistics (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    problem_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    latest_answer_status VARCHAR(20) NOT NULL,
+    is_correct BIT NOT NULL,
+    counted_as_solved BIT NOT NULL,
+    counted_as_correct BIT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT uk_problem_user_statistics UNIQUE (problem_id, user_id),
+    CONSTRAINT fk_problem_user_statistics_problem FOREIGN KEY (problem_id) REFERENCES problems (id)
+);
+
 CREATE TABLE IF NOT EXISTS problem_answer_keys (
     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     problem_id BIGINT NOT NULL,
@@ -180,3 +204,67 @@ INSERT INTO solve_attempts (user_id, chapter_id, problem_id, status, is_correct,
     (9, 1, 1004, 'SOLVED', b'0', 'INCORRECT', '2026-03-26 11:07:00'),
     (10, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:08:00'),
     (11, 1, 1004, 'SOLVED', b'1', 'CORRECT', '2026-03-26 11:09:00');
+
+INSERT INTO problem_statistics (problem_id, solved_user_count, correct_user_count, correct_rate, version, updated_at) VALUES
+    (1001, 31, 21, 68, 0, '2026-03-26 09:30:00'),
+    (1002, 0, 0, NULL, 0, '2026-03-26 00:00:00'),
+    (1003, 1, 1, NULL, 0, '2026-03-26 10:00:00'),
+    (1004, 10, 7, NULL, 0, '2026-03-26 11:09:00'),
+    (2001, 0, 0, NULL, 0, '2026-03-26 00:00:00'),
+    (2002, 0, 0, NULL, 0, '2026-03-26 00:00:00'),
+    (2003, 0, 0, NULL, 0, '2026-03-26 00:00:00')
+ON DUPLICATE KEY UPDATE
+    solved_user_count = VALUES(solved_user_count),
+    correct_user_count = VALUES(correct_user_count),
+    correct_rate = VALUES(correct_rate),
+    updated_at = VALUES(updated_at);
+
+INSERT INTO problem_user_statistics (problem_id, user_id, latest_answer_status, is_correct, counted_as_solved, counted_as_correct, created_at, updated_at) VALUES
+    (1003, 1, 'CORRECT', b'1', b'1', b'1', '2026-03-26 10:00:00', '2026-03-26 10:00:00'),
+    (1001, 2, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:00:00', '2026-03-26 09:00:00'),
+    (1001, 3, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:01:00', '2026-03-26 09:01:00'),
+    (1001, 4, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:02:00', '2026-03-26 09:02:00'),
+    (1001, 5, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:03:00', '2026-03-26 09:03:00'),
+    (1001, 6, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:04:00', '2026-03-26 09:04:00'),
+    (1001, 7, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:05:00', '2026-03-26 09:05:00'),
+    (1001, 8, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:06:00', '2026-03-26 09:06:00'),
+    (1001, 9, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:07:00', '2026-03-26 09:07:00'),
+    (1001, 10, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:08:00', '2026-03-26 09:08:00'),
+    (1001, 11, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:09:00', '2026-03-26 09:09:00'),
+    (1001, 12, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:10:00', '2026-03-26 09:10:00'),
+    (1001, 13, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:11:00', '2026-03-26 09:11:00'),
+    (1001, 14, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:12:00', '2026-03-26 09:12:00'),
+    (1001, 15, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:13:00', '2026-03-26 09:13:00'),
+    (1001, 16, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:14:00', '2026-03-26 09:14:00'),
+    (1001, 17, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:15:00', '2026-03-26 09:15:00'),
+    (1001, 18, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:16:00', '2026-03-26 09:16:00'),
+    (1001, 19, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:17:00', '2026-03-26 09:17:00'),
+    (1001, 20, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:18:00', '2026-03-26 09:18:00'),
+    (1001, 21, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:19:00', '2026-03-26 09:19:00'),
+    (1001, 22, 'CORRECT', b'1', b'1', b'1', '2026-03-26 09:20:00', '2026-03-26 09:20:00'),
+    (1001, 23, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:21:00', '2026-03-26 09:21:00'),
+    (1001, 24, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:22:00', '2026-03-26 09:22:00'),
+    (1001, 25, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:23:00', '2026-03-26 09:23:00'),
+    (1001, 26, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:24:00', '2026-03-26 09:24:00'),
+    (1001, 27, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:25:00', '2026-03-26 09:25:00'),
+    (1001, 28, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:26:00', '2026-03-26 09:26:00'),
+    (1001, 29, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:27:00', '2026-03-26 09:27:00'),
+    (1001, 30, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:28:00', '2026-03-26 09:28:00'),
+    (1001, 31, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:29:00', '2026-03-26 09:29:00'),
+    (1001, 32, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 09:30:00', '2026-03-26 09:30:00'),
+    (1004, 2, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:00:00', '2026-03-26 11:00:00'),
+    (1004, 3, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 11:01:00', '2026-03-26 11:01:00'),
+    (1004, 4, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:02:00', '2026-03-26 11:02:00'),
+    (1004, 5, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:03:00', '2026-03-26 11:03:00'),
+    (1004, 6, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 11:04:00', '2026-03-26 11:04:00'),
+    (1004, 7, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:05:00', '2026-03-26 11:05:00'),
+    (1004, 8, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:06:00', '2026-03-26 11:06:00'),
+    (1004, 9, 'INCORRECT', b'0', b'1', b'0', '2026-03-26 11:07:00', '2026-03-26 11:07:00'),
+    (1004, 10, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:08:00', '2026-03-26 11:08:00'),
+    (1004, 11, 'CORRECT', b'1', b'1', b'1', '2026-03-26 11:09:00', '2026-03-26 11:09:00')
+ON DUPLICATE KEY UPDATE
+    latest_answer_status = VALUES(latest_answer_status),
+    is_correct = VALUES(is_correct),
+    counted_as_solved = VALUES(counted_as_solved),
+    counted_as_correct = VALUES(counted_as_correct),
+    updated_at = VALUES(updated_at);

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/repository/ProblemRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/repository/ProblemRepository.java
@@ -12,4 +12,6 @@ public interface ProblemRepository {
     List<Problem> findAllByChapterId(Long chapterId);
 
     Optional<Problem> findById(Long problemId);
+
+    void lockById(Long problemId);
 }

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/repository/SolveAttemptRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/repository/SolveAttemptRepository.java
@@ -4,15 +4,12 @@ import com.project.quiz.domain.solving.AnswerStatus;
 import com.project.quiz.domain.solving.SolvedProblem;
 import com.project.quiz.domain.solving.SubmittedAnswer;
 import com.project.quiz.domain.solving.UserChapterSolvingState;
-import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
 
 import java.util.Optional;
 
 public interface SolveAttemptRepository {
 
     UserChapterSolvingState findUserChapterSolvingState(Long userId, Long chapterId);
-
-    Optional<ProblemCorrectRateSummary> findCorrectRateByProblemId(Long problemId);
 
     Optional<SolvedProblem> findLatestSolvedProblem(Long userId, Long problemId);
 

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetRandomProblemService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/GetRandomProblemService.java
@@ -1,5 +1,6 @@
 package com.project.quiz.application.solving.service;
 
+import com.project.quiz.application.statistics.service.ProblemCorrectRateService;
 import com.project.quiz.application.solving.exception.ChapterNotFoundException;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
 import com.project.quiz.application.solving.model.GetRandomProblemChoiceResult;
@@ -11,7 +12,6 @@ import com.project.quiz.application.solving.repository.SolveAttemptRepository;
 import com.project.quiz.domain.problem.Problem;
 import com.project.quiz.domain.problem.ProblemChoice;
 import com.project.quiz.domain.solving.UserChapterSolvingState;
-import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +26,7 @@ public class GetRandomProblemService {
     private final ChapterRepository chapterRepository;
     private final ProblemRepository problemRepository;
     private final SolveAttemptRepository solveAttemptRepository;
-    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+    private final ProblemCorrectRateService problemCorrectRateService;
 
     public GetRandomProblemResult getRandomProblem(GetRandomProblemCommand command) {
         Objects.requireNonNull(command, "command must not be null");
@@ -47,9 +47,7 @@ public class GetRandomProblemService {
         }
 
         Problem selectedProblem = pickRandomProblem(selectableProblems);
-        Integer correctRate = solveAttemptRepository.findCorrectRateByProblemId(selectedProblem.id())
-                .map(problemCorrectRatePolicy::calculateExposedRate)
-                .orElse(null);
+        Integer correctRate = problemCorrectRateService.getCorrectRate(selectedProblem.id());
 
         return new GetRandomProblemResult(
                 selectedProblem.id(),

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateCacheEntry.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateCacheEntry.java
@@ -1,0 +1,6 @@
+package com.project.quiz.application.statistics.repository;
+
+public record ProblemCorrectRateCacheEntry(
+        Integer correctRate
+) {
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateCacheRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateCacheRepository.java
@@ -1,0 +1,12 @@
+package com.project.quiz.application.statistics.repository;
+
+import java.util.Optional;
+
+public interface ProblemCorrectRateCacheRepository {
+
+    Optional<ProblemCorrectRateCacheEntry> find(Long problemId);
+
+    void put(Long problemId, Integer correctRate);
+
+    void evict(Long problemId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateQueryRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemCorrectRateQueryRepository.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.statistics.repository;
+
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+
+import java.util.Optional;
+
+public interface ProblemCorrectRateQueryRepository {
+
+    Optional<ProblemCorrectRateSummary> findCorrectRateSummary(Long problemId);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemStatisticsCommandRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemStatisticsCommandRepository.java
@@ -1,0 +1,14 @@
+package com.project.quiz.application.statistics.repository;
+
+import com.project.quiz.domain.statistics.ProblemStatistics;
+
+import java.util.Optional;
+
+public interface ProblemStatisticsCommandRepository {
+
+    Optional<ProblemStatistics> findStatistics(Long problemId);
+
+    Optional<ProblemStatistics> findStatisticsForUpdate(Long problemId);
+
+    void save(ProblemStatistics problemStatistics);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemStatisticsQueryRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemStatisticsQueryRepository.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.statistics.repository;
+
+import com.project.quiz.domain.statistics.ProblemStatistics;
+
+import java.util.List;
+
+public interface ProblemStatisticsQueryRepository {
+
+    List<ProblemStatistics> findAllStatistics();
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemUserStatisticsRepository.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/repository/ProblemUserStatisticsRepository.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.statistics.repository;
+
+import com.project.quiz.domain.solving.AnswerStatus;
+
+public interface ProblemUserStatisticsRepository {
+
+    boolean trySaveFirstSolved(Long problemId, Long userId, AnswerStatus answerStatus);
+
+    void updateLatestAnswerStatus(Long problemId, Long userId, AnswerStatus answerStatus);
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateCacheRefreshService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateCacheRefreshService.java
@@ -1,0 +1,24 @@
+package com.project.quiz.application.statistics.service;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
+import com.project.quiz.application.statistics.repository.ProblemStatisticsQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemCorrectRateCacheRefreshService {
+
+    private final ProblemStatisticsQueryRepository problemStatisticsQueryRepository;
+    private final ProblemCorrectRateCacheRepository problemCorrectRateCacheRepository;
+
+    @Transactional(readOnly = true)
+    public void refreshAll() {
+        problemStatisticsQueryRepository.findAllStatistics()
+                .forEach(statistics -> problemCorrectRateCacheRepository.put(
+                        statistics.problemId(),
+                        statistics.correctRate()
+                ));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateService.java
@@ -1,0 +1,36 @@
+package com.project.quiz.application.statistics.service;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheEntry;
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateQueryRepository;
+import com.project.quiz.domain.statistics.ProblemCorrectRate;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemCorrectRateService {
+
+    private final ProblemCorrectRateQueryRepository problemCorrectRateQueryRepository;
+    private final ProblemCorrectRateCacheRepository problemCorrectRateCacheRepository;
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+
+    public Integer getCorrectRate(Long problemId) {
+        Optional<ProblemCorrectRateCacheEntry> cachedCorrectRate = problemCorrectRateCacheRepository.find(problemId);
+        if (cachedCorrectRate.isPresent()) {
+            return cachedCorrectRate.get().correctRate();
+        }
+
+        Integer calculatedCorrectRate = problemCorrectRateQueryRepository.findCorrectRateSummary(problemId)
+                .flatMap(problemCorrectRatePolicy::calculate)
+                .map(ProblemCorrectRate::value)
+                .orElse(null);
+
+        problemCorrectRateCacheRepository.put(problemId, calculatedCorrectRate);
+        return calculatedCorrectRate;
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateService.java
@@ -1,0 +1,37 @@
+package com.project.quiz.application.statistics.service;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
+import com.project.quiz.application.statistics.repository.ProblemStatisticsCommandRepository;
+import com.project.quiz.application.statistics.repository.ProblemUserStatisticsRepository;
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
+import com.project.quiz.domain.statistics.ProblemStatistics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemStatisticsUpdateService {
+
+    private final ProblemStatisticsCommandRepository problemStatisticsCommandRepository;
+    private final ProblemUserStatisticsRepository problemUserStatisticsRepository;
+    private final ProblemCorrectRateCacheRepository problemCorrectRateCacheRepository;
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+
+    @Transactional
+    public void recordSolvedProblem(Long problemId, Long userId, AnswerStatus answerStatus) {
+        boolean firstSolvedUser = problemUserStatisticsRepository.trySaveFirstSolved(problemId, userId, answerStatus);
+        if (!firstSolvedUser) {
+            problemUserStatisticsRepository.updateLatestAnswerStatus(problemId, userId, answerStatus);
+            return;
+        }
+
+        ProblemStatistics problemStatistics = problemStatisticsCommandRepository.findStatisticsForUpdate(problemId)
+                .orElseThrow(() -> new IllegalStateException("Problem statistics not found. problemId=" + problemId));
+
+        problemStatistics.applyFirstSolved(answerStatus == AnswerStatus.CORRECT, problemCorrectRatePolicy);
+        problemStatisticsCommandRepository.save(problemStatistics);
+        problemCorrectRateCacheRepository.put(problemId, problemStatistics.correctRate());
+    }
+}

--- a/quiz-bootstrap/src/main/java/com/project/quiz/QuizBootstrapApplication.java
+++ b/quiz-bootstrap/src/main/java/com/project/quiz/QuizBootstrapApplication.java
@@ -2,8 +2,10 @@ package com.project.quiz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.project")
+@EnableScheduling
 public class QuizBootstrapApplication {
 
     public static void main(String[] args) {

--- a/quiz-bootstrap/src/main/resources/application.yaml
+++ b/quiz-bootstrap/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       probes:
@@ -45,3 +45,9 @@ springdoc:
   api-docs:
     path: /api-docs
   show-actuator: true
+
+quiz:
+  statistics:
+    batch:
+      enabled: true
+      refresh-ms: 600000

--- a/quiz-bootstrap/src/test/resources/application.yaml
+++ b/quiz-bootstrap/src/test/resources/application.yaml
@@ -17,3 +17,8 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /api-docs
+
+quiz:
+  statistics:
+    batch:
+      enabled: false

--- a/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRate.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRate.java
@@ -1,0 +1,6 @@
+package com.project.quiz.domain.statistics;
+
+public record ProblemCorrectRate(
+        int value
+) {
+}

--- a/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRatePolicy.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemCorrectRatePolicy.java
@@ -1,15 +1,17 @@
 package com.project.quiz.domain.statistics;
 
+import java.util.Optional;
+
 public final class ProblemCorrectRatePolicy {
 
     private static final long MINIMUM_SOLVED_USER_COUNT = 30L;
 
-    public Integer calculateExposedRate(ProblemCorrectRateSummary summary) {
+    public Optional<ProblemCorrectRate> calculate(ProblemCorrectRateSummary summary) {
         if (summary.solvedUserCount() < MINIMUM_SOLVED_USER_COUNT) {
-            return null;
+            return Optional.empty();
         }
 
         double rate = ((double) summary.correctUserCount() / summary.solvedUserCount()) * 100;
-        return (int) Math.round(rate);
+        return Optional.of(new ProblemCorrectRate((int) Math.round(rate)));
     }
 }

--- a/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemStatistics.java
+++ b/quiz-domain/src/main/java/com/project/quiz/domain/statistics/ProblemStatistics.java
@@ -1,0 +1,46 @@
+package com.project.quiz.domain.statistics;
+
+public class ProblemStatistics {
+
+    private final Long problemId;
+    private long solvedUserCount;
+    private long correctUserCount;
+    private Integer correctRate;
+
+    public ProblemStatistics(Long problemId, long solvedUserCount, long correctUserCount, Integer correctRate) {
+        this.problemId = problemId;
+        this.solvedUserCount = solvedUserCount;
+        this.correctUserCount = correctUserCount;
+        this.correctRate = correctRate;
+    }
+
+    public static ProblemStatistics initialize(Long problemId) {
+        return new ProblemStatistics(problemId, 0L, 0L, null);
+    }
+
+    public void applyFirstSolved(boolean correct, ProblemCorrectRatePolicy policy) {
+        solvedUserCount += 1;
+        if (correct) {
+            correctUserCount += 1;
+        }
+        correctRate = policy.calculate(new ProblemCorrectRateSummary(solvedUserCount, correctUserCount))
+                .map(ProblemCorrectRate::value)
+                .orElse(null);
+    }
+
+    public Long problemId() {
+        return problemId;
+    }
+
+    public long solvedUserCount() {
+        return solvedUserCount;
+    }
+
+    public long correctUserCount() {
+        return correctUserCount;
+    }
+
+    public Integer correctRate() {
+        return correctRate;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemStatisticsJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemStatisticsJpaEntity.java
@@ -1,0 +1,74 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "problem_statistics")
+public class ProblemStatisticsJpaEntity {
+
+    @Id
+    @Column(name = "problem_id")
+    private Long problemId;
+
+    @Column(name = "solved_user_count", nullable = false)
+    private long solvedUserCount;
+
+    @Column(name = "correct_user_count", nullable = false)
+    private long correctUserCount;
+
+    @Column(name = "correct_rate")
+    private Integer correctRate;
+
+    @Version
+    @Column(nullable = false)
+    private long version;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ProblemStatisticsJpaEntity() {
+    }
+
+    public static ProblemStatisticsJpaEntity create(Long problemId, long solvedUserCount, long correctUserCount, Integer correctRate, LocalDateTime updatedAt) {
+        ProblemStatisticsJpaEntity entity = new ProblemStatisticsJpaEntity();
+        entity.problemId = problemId;
+        entity.solvedUserCount = solvedUserCount;
+        entity.correctUserCount = correctUserCount;
+        entity.correctRate = correctRate;
+        entity.updatedAt = updatedAt;
+        return entity;
+    }
+
+    public void update(long solvedUserCount, long correctUserCount, Integer correctRate, LocalDateTime updatedAt) {
+        this.solvedUserCount = solvedUserCount;
+        this.correctUserCount = correctUserCount;
+        this.correctRate = correctRate;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public long getSolvedUserCount() {
+        return solvedUserCount;
+    }
+
+    public long getCorrectUserCount() {
+        return correctUserCount;
+    }
+
+    public Integer getCorrectRate() {
+        return correctRate;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemUserStatisticsJpaEntity.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/entity/ProblemUserStatisticsJpaEntity.java
@@ -1,0 +1,81 @@
+package com.project.quiz.infrastructure.persistence.entity;
+
+import com.project.quiz.domain.solving.AnswerStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "problem_user_statistics",
+        uniqueConstraints = @UniqueConstraint(name = "uk_problem_user_statistics", columnNames = {"problem_id", "user_id"})
+)
+public class ProblemUserStatisticsJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "latest_answer_status", nullable = false, length = 20)
+    private AnswerStatus latestAnswerStatus;
+
+    @Column(name = "is_correct", nullable = false)
+    private boolean correct;
+
+    @Column(name = "counted_as_solved", nullable = false)
+    private boolean countedAsSolved;
+
+    @Column(name = "counted_as_correct", nullable = false)
+    private boolean countedAsCorrect;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ProblemUserStatisticsJpaEntity() {
+    }
+
+    public static ProblemUserStatisticsJpaEntity firstSolved(Long problemId, Long userId, AnswerStatus answerStatus, LocalDateTime now) {
+        ProblemUserStatisticsJpaEntity entity = new ProblemUserStatisticsJpaEntity();
+        entity.problemId = problemId;
+        entity.userId = userId;
+        entity.latestAnswerStatus = answerStatus;
+        entity.correct = answerStatus == AnswerStatus.CORRECT;
+        entity.countedAsSolved = true;
+        entity.countedAsCorrect = answerStatus == AnswerStatus.CORRECT;
+        entity.createdAt = now;
+        entity.updatedAt = now;
+        return entity;
+    }
+
+    public void updateLatestAnswerStatus(AnswerStatus answerStatus, LocalDateTime now) {
+        this.latestAnswerStatus = answerStatus;
+        this.correct = answerStatus == AnswerStatus.CORRECT;
+        this.updatedAt = now;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemJpaRepository.java
@@ -1,14 +1,26 @@
 package com.project.quiz.infrastructure.persistence.repository;
 
 import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProblemJpaRepository extends JpaRepository<ProblemJpaEntity, Long> {
 
     List<ProblemJpaEntity> findAllByChapterIdOrderByIdAsc(@Param("chapterId") Long chapterId);
 
     boolean existsByIdAndChapterId(Long id, Long chapterId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select p
+            from ProblemJpaEntity p
+            where p.id = :problemId
+            """)
+    Optional<ProblemJpaEntity> findByIdForUpdate(@Param("problemId") Long problemId);
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemStatisticsJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemStatisticsJpaRepository.java
@@ -1,0 +1,21 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ProblemStatisticsJpaEntity;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProblemStatisticsJpaRepository extends JpaRepository<ProblemStatisticsJpaEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select ps
+            from ProblemStatisticsJpaEntity ps
+            where ps.problemId = :problemId
+            """)
+    Optional<ProblemStatisticsJpaEntity> findByProblemIdForUpdate(@Param("problemId") Long problemId);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemUserStatisticsJpaRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/persistence/repository/ProblemUserStatisticsJpaRepository.java
@@ -1,0 +1,31 @@
+package com.project.quiz.infrastructure.persistence.repository;
+
+import com.project.quiz.infrastructure.persistence.entity.ProblemUserStatisticsJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProblemUserStatisticsJpaRepository extends JpaRepository<ProblemUserStatisticsJpaEntity, Long> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO problem_user_statistics
+            (problem_id, user_id, latest_answer_status, is_correct, counted_as_solved, counted_as_correct, created_at, updated_at)
+            VALUES
+            (:problemId, :userId, :answerStatus, :correct, true, :correct, :now, :now)
+            ON DUPLICATE KEY UPDATE
+            latest_answer_status = latest_answer_status
+            """, nativeQuery = true)
+    int insertIgnoreFirstSolved(
+            @Param("problemId") Long problemId,
+            @Param("userId") Long userId,
+            @Param("answerStatus") String answerStatus,
+            @Param("correct") boolean correct,
+            @Param("now") java.time.LocalDateTime now
+    );
+
+    Optional<ProblemUserStatisticsJpaEntity> findByProblemIdAndUserId(Long problemId, Long userId);
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/ProblemRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/ProblemRepositoryImpl.java
@@ -63,4 +63,11 @@ public class ProblemRepositoryImpl implements ProblemRepository {
                         problemAnswerKeyJpaRepository.findAllByProblemIdOrderByIdAsc(problemId)
                 ));
     }
+
+    @Override
+    @Transactional
+    public void lockById(Long problemId) {
+        problemJpaRepository.findByIdForUpdate(problemId)
+                .orElseThrow(() -> new IllegalArgumentException("Problem not found. problemId=" + problemId));
+    }
 }

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemCorrectRateBatchScheduler.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemCorrectRateBatchScheduler.java
@@ -1,0 +1,20 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.service.ProblemCorrectRateCacheRefreshService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "quiz.statistics.batch", name = "enabled", havingValue = "true")
+public class ProblemCorrectRateBatchScheduler {
+
+    private final ProblemCorrectRateCacheRefreshService problemCorrectRateCacheRefreshService;
+
+    @Scheduled(fixedDelayString = "${quiz.statistics.batch.refresh-ms:600000}")
+    public void refreshCorrectRateCache() {
+        problemCorrectRateCacheRefreshService.refreshAll();
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemCorrectRateQueryRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemCorrectRateQueryRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateQueryRepository;
+import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
+import com.project.quiz.infrastructure.persistence.repository.ProblemStatisticsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProblemCorrectRateQueryRepositoryImpl implements ProblemCorrectRateQueryRepository {
+
+    private final ProblemStatisticsJpaRepository problemStatisticsJpaRepository;
+
+    @Override
+    public Optional<ProblemCorrectRateSummary> findCorrectRateSummary(Long problemId) {
+        return problemStatisticsJpaRepository.findById(problemId)
+                .map(entity -> new ProblemCorrectRateSummary(
+                        entity.getSolvedUserCount(),
+                        entity.getCorrectUserCount()
+                ));
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemStatisticsCommandRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemStatisticsCommandRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemStatisticsCommandRepository;
+import com.project.quiz.domain.statistics.ProblemStatistics;
+import com.project.quiz.infrastructure.persistence.entity.ProblemStatisticsJpaEntity;
+import com.project.quiz.infrastructure.persistence.repository.ProblemStatisticsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProblemStatisticsCommandRepositoryImpl implements ProblemStatisticsCommandRepository {
+
+    private final ProblemStatisticsJpaRepository problemStatisticsJpaRepository;
+
+    @Override
+    public Optional<ProblemStatistics> findStatistics(Long problemId) {
+        return problemStatisticsJpaRepository.findById(problemId)
+                .map(entity -> new ProblemStatistics(
+                        entity.getProblemId(),
+                        entity.getSolvedUserCount(),
+                        entity.getCorrectUserCount(),
+                        entity.getCorrectRate()
+                ));
+    }
+
+    @Override
+    public Optional<ProblemStatistics> findStatisticsForUpdate(Long problemId) {
+        return problemStatisticsJpaRepository.findByProblemIdForUpdate(problemId)
+                .map(entity -> new ProblemStatistics(
+                        entity.getProblemId(),
+                        entity.getSolvedUserCount(),
+                        entity.getCorrectUserCount(),
+                        entity.getCorrectRate()
+                ));
+    }
+
+    @Override
+    @Transactional
+    public void save(ProblemStatistics problemStatistics) {
+        ProblemStatisticsJpaEntity entity = problemStatisticsJpaRepository.findByProblemIdForUpdate(problemStatistics.problemId())
+                .orElseThrow(() -> new IllegalArgumentException("Problem statistics not found. problemId=" + problemStatistics.problemId()));
+
+        entity.update(
+                problemStatistics.solvedUserCount(),
+                problemStatistics.correctUserCount(),
+                problemStatistics.correctRate(),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemStatisticsQueryRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemStatisticsQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemStatisticsQueryRepository;
+import com.project.quiz.domain.statistics.ProblemStatistics;
+import com.project.quiz.infrastructure.persistence.repository.ProblemStatisticsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProblemStatisticsQueryRepositoryImpl implements ProblemStatisticsQueryRepository {
+
+    private final ProblemStatisticsJpaRepository problemStatisticsJpaRepository;
+
+    @Override
+    public List<ProblemStatistics> findAllStatistics() {
+        return problemStatisticsJpaRepository.findAll().stream()
+                .map(entity -> new ProblemStatistics(
+                        entity.getProblemId(),
+                        entity.getSolvedUserCount(),
+                        entity.getCorrectUserCount(),
+                        entity.getCorrectRate()
+                ))
+                .toList();
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemUserStatisticsRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/ProblemUserStatisticsRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemUserStatisticsRepository;
+import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.infrastructure.persistence.entity.ProblemUserStatisticsJpaEntity;
+import com.project.quiz.infrastructure.persistence.repository.ProblemUserStatisticsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProblemUserStatisticsRepositoryImpl implements ProblemUserStatisticsRepository {
+
+    private final ProblemUserStatisticsJpaRepository problemUserStatisticsJpaRepository;
+
+    @Override
+    @Transactional
+    public boolean trySaveFirstSolved(Long problemId, Long userId, AnswerStatus answerStatus) {
+        int insertedRows = problemUserStatisticsJpaRepository.insertIgnoreFirstSolved(
+                problemId,
+                userId,
+                answerStatus.name(),
+                answerStatus == AnswerStatus.CORRECT,
+                LocalDateTime.now()
+        );
+        return insertedRows > 0;
+    }
+
+    @Override
+    @Transactional
+    public void updateLatestAnswerStatus(Long problemId, Long userId, AnswerStatus answerStatus) {
+        problemUserStatisticsJpaRepository.findByProblemIdAndUserId(problemId, userId)
+                .ifPresent(entity -> entity.updateLatestAnswerStatus(answerStatus, LocalDateTime.now()));
+    }
+}

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepository.java
@@ -1,0 +1,58 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheEntry;
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisProblemCorrectRateCacheRepository implements ProblemCorrectRateCacheRepository {
+
+    private static final String KEY_PREFIX = "problem:correct-rate:";
+    private static final String NULL_SENTINEL = "NULL";
+    private static final Duration TTL = Duration.ofHours(6);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public Optional<ProblemCorrectRateCacheEntry> find(Long problemId) {
+        try {
+            String cachedValue = stringRedisTemplate.opsForValue().get(key(problemId));
+            if (cachedValue == null) {
+                return Optional.empty();
+            }
+            if (NULL_SENTINEL.equals(cachedValue)) {
+                return Optional.of(new ProblemCorrectRateCacheEntry(null));
+            }
+            return Optional.of(new ProblemCorrectRateCacheEntry(Integer.valueOf(cachedValue)));
+        } catch (RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(Long problemId, Integer correctRate) {
+        try {
+            String value = correctRate == null ? NULL_SENTINEL : String.valueOf(correctRate);
+            stringRedisTemplate.opsForValue().set(key(problemId), value, TTL);
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    @Override
+    public void evict(Long problemId) {
+        try {
+            stringRedisTemplate.delete(key(problemId));
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    private String key(Long problemId) {
+        return KEY_PREFIX + problemId;
+    }
+}


### PR DESCRIPTION
## 요약
  - 정답률 계산을 MySQL 통계 스냅샷 + Redis 캐시 구조로 정리했습니다.
  - `problem_statistics`, `problem_user_statistics` 기반으로 distinct user 집계를 반영했습니다.
  - Redis 재동기화 배치를 추가했습니다.

  ## 변경 사항
  - statistics 도메인 및 repository/service 추가
  - Redis `cache-aside + write-through` 반영
  - `problem_statistics` row lock 기반 동시성 제어
  - 배치 스케줄러 추가
  - 시드 데이터와 설정 반영

  ## 이유
  정답률 계산 로직을 단순 조회 SQL에서 분리하고,
  정합성은 MySQL이, 조회 성능은 Redis가 담당하도록 역할을 명확히 했습니다.

  ## 검증
  ```bash
  ./gradlew :quiz-application:test
  ./gradlew :quiz-infrastructure:test
