### PR TITLE
[Docs] README 분리 및 architecture/report 문서 구조 재정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,536 +2,68 @@
 
 학습 플랫폼의 핵심 기능인 `단원별 문제 풀이`를 중심으로 구현한 Spring Boot 3.3 / Java 21 멀티 모듈 프로젝트입니다.
 
-현재 문서 기준 구현 범위는 아래 네 API입니다.
+## 구현 범위
 
 - 랜덤 문제 조회
 - 문제 넘기기
 - 문제 제출
 - 풀었던 문제 상세 조회
 
-## 1. 프로젝트 목표
-
-이 프로젝트는 단순 CRUD보다 아래 관점을 더 중요하게 두고 구현했습니다.
-
-- 도메인 규칙을 계층 밖으로 새지 않게 유지
-- 멀티 모듈 구조로 책임을 명확히 분리
-- 테스트 가능한 구조 유지
-- 조회 성능을 고려한 설계
-- Docker Compose로 애플리케이션과 인프라를 한 번에 실행 가능하게 구성
-
-## 2. 멀티 모듈 구조
-
-```text
-root
-├── quiz-bootstrap
-├── quiz-api
-├── quiz-application
-├── quiz-domain
-└── quiz-infrastructure
-```
-
-### `quiz-bootstrap`
-
-실행 모듈입니다.
-
-- `@SpringBootApplication`
-- 실제 애플리케이션 조립
-- 테스트 시 end-to-end 검증 진입점
-
-### `quiz-api`
-
-HTTP 입출력 계층입니다.
-
-- controller
-- request/response DTO
-- validation
-- Swagger 문서화
-- exception -> HTTP 응답 변환
-
-### `quiz-application`
-
-유스케이스 계층입니다.
-
-- service
-- command/result model
-- repository interface
-- transaction boundary
-
-### `quiz-domain`
-
-순수 도메인 모델 계층입니다.
-
-- 문제
-- 선택지
-- 사용자-단원 풀이 상태
-- 정답률 정책
-
-### `quiz-infrastructure`
-
-영속성 및 외부 기술 구현 계층입니다.
-
-- JPA entity
-- Spring Data JPA repository
-- application repository 구현체
-
-## 3. 왜 이렇게 나눴는가
-
-이 과제는 멀티 모듈과 DDD 원칙을 요구합니다. 따라서 실행, API, 유스케이스, 도메인, 영속성을 같은 모듈에 섞지 않고 분리했습니다.
-
-이 구조의 장점은 아래와 같습니다.
-
-- API 요구사항 변경이 도메인 모델에 직접 영향을 덜 줍니다.
-- 도메인 규칙을 Spring MVC/JPA 없이 단위 테스트할 수 있습니다.
-- 조회 성능 최적화가 필요할 때 `quiz-infrastructure`에서 집중적으로 개선할 수 있습니다.
-- `quiz-bootstrap`에서만 실행과 조립을 담당하므로 배포 단위가 명확합니다.
-
-## 4. DDD 관점 정리
-
-### Ubiquitous Language
-
-이 프로젝트에서는 아래 용어를 공통 언어로 정했습니다.
-
-- `Chapter`: 문제를 묶는 단원
-- `Problem`: 사용자가 푸는 문제
-- `Choice`: 객관식 선택지
-- `SolveAttempt`: 사용자의 풀이 또는 건너뛰기 기록
-- `SkippedProblem`: 사용자가 직전에 넘긴 문제
-- `CorrectRate`: 문제 정답률
-- `UserChapterSolvingState`: 특정 사용자-특정 단원 기준 풀이 상태
-
-### Bounded Context
-
-현재 기능 기준으로 도메인을 크게 세 개의 문맥으로 해석했습니다.
-
-- `problem`
-  - 문제와 선택지 자체
-- `solving`
-  - 사용자의 풀이 상태, 문제 넘기기, 출제 가능 여부
-- `statistics`
-  - 정답률 공개 정책
-
-프로젝트 규모상 별도 모듈로 더 쪼개지는 않았고, `quiz-domain` 내부 패키지로 경계를 표현했습니다.
-
-### Aggregate Root 관점
-
-현재 구현에서 핵심적으로 본 aggregate root 성격의 모델은 아래입니다.
-
-- `Problem`
-- `UserChapterSolvingState`
-
-특히 이 요구사항의 핵심 규칙은 `Chapter` 단독보다 `사용자 + chapter + 직전 skip + 이미 푼 문제` 조합에 가깝기 때문에, `UserChapterSolvingState`를 중요한 도메인 모델로 해석했습니다.
-
-## 5. API
-
-## 5.1 랜덤 문제 조회
-
-- `POST /api/problems/random`
-
-요청
-
-```json
-{
-  "chapterId": 1,
-  "userId": 1
-}
-```
-
-응답 예시
-
-```json
-{
-  "problemId": 1001,
-  "content": "Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.",
-  "choices": ["int", "long", "boolean", "short", "byte"],
-  "answerCorrectRate": 68
-}
-```
-
-동작 규칙
-
-- 이미 푼 문제 제외
-- 직전에 skip한 문제 제외
-- 남은 문제 중 랜덤 1개 반환
-- 30명 이상 풀이 시 정답률 공개
-- 30명 미만이면 `answerCorrectRate = null`
-
-오류 응답
-
-- `400`: 요청 검증 실패
-- `404`: 존재하지 않는 chapter
-- `409`: 더 이상 출제 가능한 문제 없음
-
-시퀀스 다이어그램
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Controller as ProblemController
-    participant Service as GetRandomProblemService
-    participant ChapterRepo as ChapterRepository
-    participant ProblemRepo as ProblemRepository
-    participant AttemptRepo as SolveAttemptRepository
-    participant DB as MySQL
-
-    User->>Controller: POST /api/problems/random
-    Controller->>Service: getRandomProblem(userId, chapterId)
-    Service->>ChapterRepo: existsById(chapterId)
-    ChapterRepo->>DB: SELECT chapter
-    DB-->>ChapterRepo: exists
-    ChapterRepo-->>Service: true
-    Service->>AttemptRepo: findUserChapterSolvingState(userId, chapterId)
-    AttemptRepo->>DB: SELECT solved/skipped attempts
-    DB-->>AttemptRepo: solving state
-    AttemptRepo-->>Service: UserChapterSolvingState
-    Service->>ProblemRepo: findAllByChapterId(chapterId)
-    ProblemRepo->>DB: SELECT problems + choices + answer keys
-    DB-->>ProblemRepo: problem list
-    ProblemRepo-->>Service: problem list
-    Service->>Service: solved/skip 제외 후 랜덤 선택
-    Service->>AttemptRepo: findCorrectRateByProblemId(problemId)
-    AttemptRepo->>DB: SELECT correct rate summary
-    DB-->>AttemptRepo: solved_count, correct_count
-    AttemptRepo-->>Service: ProblemCorrectRateSummary
-    Service-->>Controller: GetRandomProblemResult
-    Controller-->>User: 200 OK
-```
-
-## 5.2 문제 넘기기
-
-- `POST /api/problems/skip`
-
-요청
-
-```json
-{
-  "chapterId": 1,
-  "userId": 1,
-  "problemId": 1001
-}
-```
-
-응답
-
-- 현재 문제를 `SKIPPED`로 기록한 뒤
-- 같은 단원에서 다음 랜덤 문제 1개를 바로 반환
-
-오류 응답
-
-- `400`: 요청 검증 실패
-- `404`: 존재하지 않는 chapter 또는 해당 chapter에 속하지 않는 problem
-- `409`: skip 이후 더 이상 출제 가능한 문제 없음
-
-시퀀스 다이어그램
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Controller as ProblemController
-    participant SkipService as SkipProblemService
-    participant RandomService as GetRandomProblemService
-    participant ChapterRepo as ChapterRepository
-    participant ProblemRepo as ProblemRepository
-    participant AttemptRepo as SolveAttemptRepository
-    participant DB as MySQL
-
-    User->>Controller: POST /api/problems/skip
-    Controller->>SkipService: skipProblem(userId, chapterId, problemId)
-    SkipService->>ChapterRepo: existsById(chapterId)
-    ChapterRepo->>DB: SELECT chapter
-    DB-->>ChapterRepo: exists
-    SkipService->>ProblemRepo: existsByIdAndChapterId(problemId, chapterId)
-    ProblemRepo->>DB: SELECT problem
-    DB-->>ProblemRepo: exists
-    SkipService->>AttemptRepo: saveSkippedProblem(userId, chapterId, problemId)
-    AttemptRepo->>DB: INSERT solve_attempts(SKIPPED)
-    DB-->>AttemptRepo: saved
-    SkipService->>RandomService: getRandomProblem(userId, chapterId)
-    RandomService-->>SkipService: GetRandomProblemResult
-    SkipService-->>Controller: GetRandomProblemResult
-    Controller-->>User: 200 OK
-```
-
-## 5.3 문제 제출
-
-- `POST /api/problems/submit`
-
-요청
-
-```json
-{
-  "problemId": 3,
-  "userId": 1,
-  "answerType": "OBJECTIVE",
-  "selectedChoices": [1, 3]
-}
-```
-
-응답 예시
-
-```json
-{
-  "problemId": 3,
-  "answerType": "OBJECTIVE",
-  "answerStatus": "PARTIAL",
-  "explanation": "정답은 1번과 2번입니다.",
-  "problemAnswers": ["1", "2"]
-}
-```
-
-동작 규칙
-
-- 객관식/주관식 모두 지원
-- 객관식은 복수 정답 가능
-- 정답/부분 정답/오답 판정
-- 제출 즉시 해설과 정답 반환
-- 제출 이력과 사용자 답안 저장
-
-오류 응답
-
-- `400`: 요청 검증 실패
-- `404`: 존재하지 않는 problem
-- `409`: 문제 답안 형식과 제출 형식 불일치
-
-시퀀스 다이어그램
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Controller as ProblemController
-    participant Service as SubmitProblemAnswerService
-    participant ProblemRepo as ProblemRepository
-    participant AttemptRepo as SolveAttemptRepository
-    participant Domain as Problem
-    participant DB as MySQL
-
-    User->>Controller: POST /api/problems/submit
-    Controller->>Service: submit(problemId, userId, answerType, userAnswer)
-    Service->>ProblemRepo: findById(problemId)
-    ProblemRepo->>DB: SELECT problem + choices + answer keys
-    DB-->>ProblemRepo: problem aggregate
-    ProblemRepo-->>Service: Problem
-    Service->>Domain: grade(submittedAnswer)
-    Domain-->>Service: GradingResult
-    Service->>AttemptRepo: saveSolvedAttempt
-    AttemptRepo->>DB: INSERT solve_attempts(SOLVED)
-    AttemptRepo->>DB: INSERT solve_attempt_answers
-    DB-->>AttemptRepo: saved
-    AttemptRepo-->>Service: done
-    Service-->>Controller: SubmitProblemAnswerResult
-    Controller-->>User: 200 OK
-```
-
-## 5.4 풀었던 문제 상세 조회
-
-- `POST /api/problems/detail`
-
-요청
-
-```json
-{
-  "userId": 1,
-  "problemId": 3
-}
-```
-
-응답 예시
-
-```json
-{
-  "problemId": 3,
-  "answerType": "OBJECTIVE",
-  "answerStatus": "PARTIAL",
-  "explanation": "정답은 1번과 2번입니다.",
-  "problemAnswers": ["1", "2"],
-  "userAnswers": ["1", "3"],
-  "answerCorrectRate": 67
-}
-```
-
-동작 규칙
-
-- 사용자 + 문제 기준 최신 `SOLVED` 이력을 조회
-- 정답, 사용자 답안, 해설, 정답률을 함께 반환
-- 풀이 이력이 없으면 예외 처리
-
-오류 응답
-
-- `400`: 요청 검증 실패
-- `404`: 존재하지 않는 problem 또는 풀이 이력 없음
-
-시퀀스 다이어그램
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Controller as ProblemController
-    participant Service as GetSolvedProblemDetailService
-    participant ProblemRepo as ProblemRepository
-    participant AttemptRepo as SolveAttemptRepository
-    participant DB as MySQL
-
-    User->>Controller: POST /api/problems/detail
-    Controller->>Service: getDetail(userId, problemId)
-    Service->>ProblemRepo: findById(problemId)
-    ProblemRepo->>DB: SELECT problem + answer keys
-    DB-->>ProblemRepo: problem
-    ProblemRepo-->>Service: Problem
-    Service->>AttemptRepo: findLatestSolvedProblem(userId, problemId)
-    AttemptRepo->>DB: SELECT latest solved attempt
-    AttemptRepo->>DB: SELECT solve_attempt_answers
-    DB-->>AttemptRepo: solved attempt + user answers
-    AttemptRepo-->>Service: SolvedProblem
-    Service->>AttemptRepo: findCorrectRateByProblemId(problemId)
-    AttemptRepo->>DB: SELECT correct rate summary
-    DB-->>AttemptRepo: solved_count, correct_count
-    AttemptRepo-->>Service: ProblemCorrectRateSummary
-    Service-->>Controller: GetSolvedProblemDetailResult
-    Controller-->>User: 200 OK
-```
-
-## 6. 현재 구현된 핵심 규칙
-
-- 직전 skip 문제는 다음 랜덤 추출 대상에서 제외
-- solved 상태 문제는 랜덤 후보에서 제외
-- 최신 `SOLVED` 이력 기준으로 상세 조회
-- 문제 제출 시 사용자 답안 별도 저장
-- 문제 정답률은 `solve_attempts` 집계를 통해 계산
-- 정답률 공개 규칙은 `ProblemCorrectRatePolicy`가 담당
-
-## 7. JPA 설계 관점
-
-현재 JPA entity는 객체 연관관계를 최소화하고 FK id 기반으로 설계했습니다.
-
-예를 들면:
-
-- `ProblemJpaEntity`는 `ChapterJpaEntity`를 직접 참조하지 않고 `chapterId`만 가집니다.
-- `ProblemChoiceJpaEntity`도 `ProblemJpaEntity` 객체를 잡지 않고 `problemId`만 가집니다.
-
-이렇게 한 이유는 아래와 같습니다.
-
-- JPA 프록시와 지연 로딩 의존 최소화
-- aggregate 경계 명확화
-- 조회 쿼리 의도를 더 명시적으로 표현
-- `quiz-domain`과 `quiz-infrastructure` 분리 유지
-
-DB 레벨 FK 제약은 유지하지만, JPA 객체 그래프는 남용하지 않는 방향을 선택했습니다.
-
-## 8. 현재 동작하는 쿼리와 성능 관점
-
-현재 랜덤 문제 조회는 아래 순서로 동작합니다.
-
-1. chapter 존재 여부 확인
-2. chapter의 문제 목록 조회
-3. 문제 id 목록으로 선택지 일괄 조회
-4. 사용자 solved 문제 목록 조회
-5. 사용자의 마지막 skipped 문제 조회
-6. 특정 문제의 정답률 집계 조회
-
-현재 구조의 장점은 아래와 같습니다.
-
-- `Problem -> Choice`를 join fetch로 크게 끌고 오지 않고 명시 조회 후 조합합니다.
-- solved 문제 목록과 마지막 skipped 문제 조회가 분리되어 있어 의도가 명확합니다.
-- 정답률 집계는 `solve_attempts`에서 count/sum 집계로 처리합니다.
-
-현재 한계도 있습니다.
-
-- 랜덤 선택 전 chapter 내 문제를 모두 메모리로 가져와 필터링합니다.
-- 문제 수가 매우 많아지면 이 부분은 더 최적화가 필요합니다.
-- 지금은 과제 범위에 맞춰 읽기 쉬운 구조를 우선했습니다.
-
-향후 개선 여지는 아래와 같습니다.
-
-- DB에서 후보 문제를 더 직접적으로 줄이는 쿼리
-- `solve_attempts(user_id, chapter_id, status)` 인덱스 최적화
-- 정답률 집계 캐시 또는 별도 통계 테이블
-
-즉 현재 성능은 "과제 구현 단계에서는 합리적"이지만, 대규모 데이터 기준 최적화가 끝난 상태는 아닙니다.
-
-## 9. 테스트 전략
-
-현재 테스트는 계층별로 나눴습니다.
-
-- application unit test
-  - `GetRandomProblemServiceTest`
-  - `SkipProblemServiceTest`
-  - `SubmitProblemAnswerServiceTest`
-  - `GetSolvedProblemDetailServiceTest`
-- api slice test
-  - `@WebMvcTest` 기반 `ProblemControllerTest`
-- infrastructure integration test
-  - `SolvingRepositoryIntegrationTest`
-- bootstrap end-to-end test
-  - `GetRandomProblemEndToEndTest`
-
-이 구조로 인해 규칙, HTTP 계약, JPA 매핑, 실제 계층 연결을 각각 분리해서 검증할 수 있습니다.
-
-## 10. Docker Compose 실행
-
-### 실행
+## 빠른 실행
 
 ```bash
 docker compose up --build
+./gradlew test
 ```
 
-실행 구성
+## 문서
 
-- `app`: Spring Boot 애플리케이션
-- `mysql`: 메인 DB
-- `redis`: 이후 사용자 시도 횟수/캐시 계층 확장용
+### 아키텍처
 
-### 시드 데이터
+- [01. 아키텍처 개요](docs/architecture/01.Architecture-Overview.md)
+- [02. 도메인 설계](docs/architecture/02.Domain-Design.md)
+- [03. 시퀀스 다이어그램](docs/architecture/03.Sequence-Diagrams.md)
+- [04. ERD / JPA 설계](docs/architecture/04.ERD-and-JPA.md)
+- [05. API 설계](docs/architecture/05.API-Design.md)
+- [06. 테스트 전략](docs/architecture/06.Test-Strategy.md)
 
-MySQL 컨테이너는 아래 디렉터리의 SQL을 초기화 시 실행합니다.
+### 보고서
 
-- `docker/mysql/init/01-schema-and-seed.sql`
+- [01. 정답률 계산과 경쟁 상태 분석](docs/report/01.CorrectRate-Concurrency-Report.md)
+- [02. 캐시 전략과 배치 재동기화](docs/report/02.Cache-and-Batch-Report.md)
+- [03. 성능 테스트 보고서](docs/report/03.Load-Test-Report.md)
 
-이 SQL은 아래를 수행합니다.
+## 실행 정보
 
-- 테이블 생성
-- 예제 chapter/problem/problem_choices/solve_attempts 삽입
+### 애플리케이션
 
-중요한 점:
+- Swagger: `http://localhost:8080/swagger-ui.html`
+- Health: `http://localhost:8080/actuator/health`
+- Prometheus: `http://localhost:8080/actuator/prometheus`
 
-- 이 init SQL은 MySQL 볼륨이 처음 만들어질 때만 실행됩니다.
-- 이미 기존 볼륨이 있으면 새 데이터가 반영되지 않습니다.
-
-초기 데이터를 다시 넣으려면:
+### 성능 테스트 환경
 
 ```bash
-docker compose down -v
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.perf.yml up --build -d
 ```
-
-## 11. 로컬 실행
 
 ```bash
-./gradlew :quiz-bootstrap:bootRun
+docker compose -f docker-compose.yml -f docker-compose.perf.yml run --rm -e TEST_ID=random-cold-001 k6 run -o experimental-prometheus-rw /work/perf/k6/random.js
+docker compose -f docker-compose.yml -f docker-compose.perf.yml run --rm -e TEST_ID=submit-hot-1002-001 -e HOT_PROBLEM_ID=1002 k6 run -o experimental-prometheus-rw /work/perf/k6/submit.js
+docker compose -f docker-compose.yml -f docker-compose.perf.yml run --rm -e TEST_ID=detail-warm-001 -e DETAIL_USER_ID=1 -e DETAIL_PROBLEM_ID=1003 k6 run -o experimental-prometheus-rw /work/perf/k6/detail.js
+docker compose -f docker-compose.yml -f docker-compose.perf.yml run --rm -e TEST_ID=mixed-001 -e HOT_PROBLEM_ID=1002 -e DETAIL_USER_ID=1 -e DETAIL_PROBLEM_ID=1003 k6 run -o experimental-prometheus-rw /work/perf/k6/mixed.js
 ```
 
-Swagger:
+- Grafana: `http://localhost:3000`
+- Prometheus: `http://localhost:9090`
+- 성능 테스트 가이드: [`perf/RESULTS.md`](/Users/jonghun/dev/project/java/teamsky/perf/RESULTS.md)
 
-- `http://localhost:8080/swagger-ui.html`
+#### k6 Docker 실행 명령
 
-헬스 체크:
 
-- `http://localhost:8080/api/health`
-- `http://localhost:8080/actuator/health`
+## 핵심 설계 포인트
 
-## 12. 주요 테스트 명령
-
-```bash
-./gradlew :quiz-application:test
-./gradlew :quiz-api:test
-./gradlew :quiz-infrastructure:test
-./gradlew :quiz-bootstrap:test
-```
-
-## 13. 현재 범위와 남은 작업
-
-현재 구현 범위:
-
-- 랜덤 문제 조회
-- 문제 넘기기
-- Swagger 문서화
-- Docker Compose 기반 실행
-- 계층별 테스트
+- 정답률은 `problem_statistics`를 기준 저장소로 두고 Redis 캐시를 우선 조회합니다.
+- `problem_user_statistics`로 `distinct user` 기준 집계를 보장합니다.
+- 제출 시 통계 갱신은 동기 처리하고, Redis write-through를 사용합니다.
+- 별도 배치는 Redis 재동기화와 복구를 위한 보조 기능으로 동작합니다.

--- a/docs/architecture/01.Architecture-Overview.md
+++ b/docs/architecture/01.Architecture-Overview.md
@@ -1,0 +1,76 @@
+# 아키텍처 개요
+
+## 프로젝트 목표
+
+이 프로젝트는 단순 CRUD보다 아래 관점을 우선해 구현했습니다.
+
+- 도메인 규칙을 계층 밖으로 새지 않게 유지
+- 멀티 모듈 구조로 책임을 명확히 분리
+- 테스트 가능한 구조 유지
+- 조회 성능과 정답률 계산 책임 분리
+- Docker Compose로 애플리케이션과 인프라를 한 번에 실행 가능하게 구성
+
+## 멀티 모듈 구조
+
+```text
+root
+├── quiz-bootstrap
+├── quiz-api
+├── quiz-application
+├── quiz-domain
+└── quiz-infrastructure
+```
+
+### `quiz-bootstrap`
+
+- `@SpringBootApplication`
+- 실제 애플리케이션 조립
+- scheduling 활성화
+- end-to-end 테스트 진입점
+
+### `quiz-api`
+
+- controller
+- request/response DTO
+- validation
+- Swagger 문서화
+- exception -> HTTP 응답 변환
+
+### `quiz-application`
+
+- service
+- command/result model
+- repository interface
+- transaction boundary
+
+### `quiz-domain`
+
+- 문제
+- 선택지
+- 사용자 풀이 상태
+- 정답률 정책
+
+### `quiz-infrastructure`
+
+- JPA entity
+- Spring Data JPA repository
+- Redis cache 구현
+- application repository 구현체
+
+## 왜 이렇게 나눴는가
+
+이 과제는 멀티 모듈과 DDD 원칙을 요구합니다. 따라서 실행, API, 유스케이스, 도메인, 영속성을 같은 모듈에 섞지 않고 분리했습니다.
+
+이 구조의 장점은 아래와 같습니다.
+
+- API 요구사항 변경이 도메인 모델에 직접 영향을 덜 줍니다.
+- 도메인 규칙을 Spring MVC/JPA 없이 단위 테스트할 수 있습니다.
+- 조회 성능 최적화가 필요할 때 `quiz-infrastructure`에서 집중적으로 개선할 수 있습니다.
+- `quiz-bootstrap`에서만 실행과 조립을 담당하므로 배포 단위가 명확합니다.
+
+## 현재 구현 범위
+
+- 랜덤 문제 조회
+- 문제 넘기기
+- 문제 제출
+- 풀었던 문제 상세 조회

--- a/docs/architecture/02.Domain-Design.md
+++ b/docs/architecture/02.Domain-Design.md
@@ -1,0 +1,69 @@
+# 도메인 설계
+
+## DDD 학습과 적용
+
+<img src="../images/ddd_image.png" alt="ddd overview" width="400" />
+
+이번 과제에서는 DDD를 학습하면서 아래 기준을 의식해 구조를 정리했습니다.
+
+- 공통 언어를 먼저 정리하고 코드 이름에 반영할 것
+- 문제, 풀이, 통계라는 문맥을 구분할 것
+- 비즈니스 규칙은 controller나 JPA entity보다 domain/application에서 읽히게 할 것
+
+그 결과 현재 구조는 `Problem`, `UserChapterSolvingState`, `SolvedProblem`, `ProblemCorrectRatePolicy`처럼
+도메인 개념이 직접 드러나는 방향으로 정리했습니다.
+
+## Ubiquitous Language
+
+- `Chapter`: 문제를 묶는 단원
+- `Problem`: 사용자가 푸는 문제
+- `Choice`: 객관식 선택지
+- `SolveAttempt`: 사용자의 풀이 또는 건너뛰기 기록
+- `SkippedProblem`: 사용자가 직전에 넘긴 문제
+- `CorrectRate`: 문제 정답률
+- `UserChapterSolvingState`: 특정 사용자-특정 단원 기준 풀이 상태
+
+## Bounded Context
+
+- `problem`
+  - 문제와 선택지 자체
+- `solving`
+  - 사용자의 풀이 상태, 문제 넘기기, 출제 가능 여부
+- `statistics`
+  - 정답률 공개 정책과 집계 스냅샷
+
+프로젝트 규모상 별도 모듈로 더 쪼개지는 않았고, `quiz-domain` 내부 패키지로 경계를 표현했습니다.
+
+## Aggregate Root 관점
+
+현재 구현에서 핵심적으로 본 aggregate root 성격의 모델은 아래입니다.
+
+- `Problem`
+- `UserChapterSolvingState`
+
+특히 요구사항의 핵심 규칙은 `사용자 + chapter + 직전 skip + 이미 푼 문제` 조합에 가깝기 때문에,
+`UserChapterSolvingState`를 중요한 도메인 모델로 해석했습니다.
+
+## 현재 구현된 핵심 규칙
+
+- 직전 skip 문제는 다음 랜덤 추출 대상에서 제외
+- solved 상태 문제는 랜덤 후보에서 제외
+- 최신 `SOLVED` 이력 기준으로 상세 조회
+- 문제 제출 시 사용자 답안 별도 저장
+- 문제 제출 시 `problem_user_statistics`, `problem_statistics`를 갱신
+- 정답률 조회는 Redis 캐시 우선, DB fallback 구조
+- 정답률 공개 규칙은 `ProblemCorrectRatePolicy`가 담당
+
+## 주관식 답변에 LLM을 활용할 수 있다면
+
+현재 구현은 주관식 답안을 정규화한 문자열 일치 기준으로 처리합니다. 실제 서비스라면 단순 문자열 일치만으로는 정답 인정 범위가 너무 좁을 수 있다고 보았습니다.
+
+확장 기준은 아래와 같습니다.
+
+- 정답의 공식 답변과 허용 가능한 유의어를 먼저 정의
+- LLM은 자유 생성보다 "정답 의미와 일치하는지 분류" 역할로 제한
+- 결과는 `정답 / 오답 / 애매함` 형태의 classification으로 받기
+- 애매한 경우는 사람이 검토하거나 보수적으로 오답 처리
+- 동일 답변 반복 비용을 줄이기 위해 캐시 또는 임베딩 기반 전처리를 고려
+
+즉, LLM을 채점기의 핵심 로직으로 바로 두기보다 의미 유사성 판단을 보조하는 제한된 판별기로 쓰는 것이 더 안전하다고 보았습니다.

--- a/docs/architecture/03.Sequence-Diagrams.md
+++ b/docs/architecture/03.Sequence-Diagrams.md
@@ -1,0 +1,115 @@
+# 시퀀스 다이어그램
+
+## 1. 랜덤 문제 조회
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as ProblemController
+    participant App as Application Service
+    participant Redis as Redis
+    participant MySQL as MySQL
+
+    User->>API: POST /api/problems/random
+    API->>App: 랜덤 문제 조회
+    App->>MySQL: chapter / 문제 / solved / skipped 조회
+    MySQL-->>App: 출제 가능한 문제 목록
+    App->>App: 랜덤 문제 선택
+    App->>Redis: 정답률 캐시 조회
+    alt cache hit
+        Redis-->>App: cached correctRate
+    else cache miss
+        Redis-->>App: miss
+        App->>MySQL: problem_statistics 조회
+        MySQL-->>App: solved_user_count, correct_user_count
+        App->>App: 정답률 정책 적용
+        App->>Redis: 정답률 캐시 저장
+    end
+    App-->>API: 문제 + 정답률
+    API-->>User: 200 OK
+```
+
+## 2. 문제 넘기기
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as ProblemController
+    participant App as Application Service
+    participant Redis as Redis
+    participant MySQL as MySQL
+
+    User->>API: POST /api/problems/skip
+    API->>App: 문제 넘기기
+    App->>MySQL: skip 이력 저장
+    MySQL-->>App: saved
+    App->>MySQL: 다음 출제 후보 조회
+    MySQL-->>App: 출제 가능한 문제 목록
+    App->>Redis: 정답률 캐시 조회
+    alt cache miss
+        Redis-->>App: miss
+        App->>MySQL: problem_statistics 조회
+        MySQL-->>App: statistics
+        App->>Redis: 정답률 캐시 저장
+    else cache hit
+        Redis-->>App: cached correctRate
+    end
+    App-->>API: 다음 문제
+    API-->>User: 200 OK
+```
+
+## 3. 문제 제출
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as ProblemController
+    participant App as Application Service
+    participant Redis as Redis
+    participant MySQL as MySQL
+
+    User->>API: POST /api/problems/submit
+    API->>App: 문제 제출
+    App->>MySQL: 문제/정답 조회
+    MySQL-->>App: problem aggregate
+    App->>App: 채점
+    App->>MySQL: solve_attempts / answers 저장
+    App->>MySQL: problem_user_statistics 최초 제출 시도
+    alt 최초 풀이 사용자
+        App->>MySQL: problem_statistics row lock 조회
+        MySQL-->>App: locked statistics row
+        App->>MySQL: solved/correct/rate 갱신
+        App->>Redis: 정답률 캐시 write-through
+    else 이미 집계된 사용자
+        App->>MySQL: latest answer status 갱신
+    end
+    App-->>API: 채점 결과 + 해설
+    API-->>User: 200 OK
+```
+
+## 4. 풀었던 문제 상세 조회
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant API as ProblemController
+    participant App as Application Service
+    participant Redis as Redis
+    participant MySQL as MySQL
+
+    User->>API: POST /api/problems/detail
+    API->>App: 풀이 상세 조회
+    App->>MySQL: 문제 / 최신 solved 이력 / userAnswers 조회
+    MySQL-->>App: problem + solved detail
+    App->>Redis: 정답률 캐시 조회
+    alt cache hit
+        Redis-->>App: cached correctRate
+    else cache miss
+        Redis-->>App: miss
+        App->>MySQL: problem_statistics 조회
+        MySQL-->>App: statistics
+        App->>Redis: 정답률 캐시 저장
+    end
+    App-->>API: 해설 + 정답 + 제출 답안 + 정답률
+    API-->>User: 200 OK
+```

--- a/docs/architecture/04.ERD-and-JPA.md
+++ b/docs/architecture/04.ERD-and-JPA.md
@@ -1,0 +1,121 @@
+# ERD / JPA 설계
+
+## ERD
+
+```mermaid
+erDiagram
+    CHAPTERS ||--o{ PROBLEMS : has
+    PROBLEMS ||--o{ PROBLEM_CHOICES : has
+    PROBLEMS ||--o{ PROBLEM_ANSWER_KEYS : has
+    CHAPTERS ||--o{ SOLVE_ATTEMPTS : contains
+    PROBLEMS ||--o{ SOLVE_ATTEMPTS : solved
+    SOLVE_ATTEMPTS ||--o{ SOLVE_ATTEMPT_ANSWERS : records
+    PROBLEMS ||--|| PROBLEM_STATISTICS : aggregates
+    PROBLEMS ||--o{ PROBLEM_USER_STATISTICS : tracks
+
+    CHAPTERS {
+        BIGINT id PK
+        VARCHAR title
+    }
+
+    PROBLEMS {
+        BIGINT id PK
+        BIGINT chapter_id FK
+        TEXT content
+        VARCHAR answer_format
+        VARCHAR problem_type
+        TEXT explanation
+    }
+
+    PROBLEM_CHOICES {
+        BIGINT id PK
+        BIGINT problem_id FK
+        INT sequence
+        TEXT content
+    }
+
+    PROBLEM_ANSWER_KEYS {
+        BIGINT id PK
+        BIGINT problem_id FK
+        VARCHAR answer_format
+        INT choice_sequence
+        TEXT subjective_answer
+    }
+
+    SOLVE_ATTEMPTS {
+        BIGINT id PK
+        BIGINT user_id
+        BIGINT chapter_id FK
+        BIGINT problem_id FK
+        VARCHAR status
+        BIT is_correct
+        VARCHAR answer_status
+        DATETIME created_at
+    }
+
+    SOLVE_ATTEMPT_ANSWERS {
+        BIGINT id PK
+        BIGINT solve_attempt_id FK
+        VARCHAR answer_format
+        INT choice_sequence
+        TEXT subjective_answer
+    }
+
+    PROBLEM_STATISTICS {
+        BIGINT problem_id PK
+        BIGINT solved_user_count
+        BIGINT correct_user_count
+        INT correct_rate
+        BIGINT version
+        DATETIME updated_at
+    }
+
+    PROBLEM_USER_STATISTICS {
+        BIGINT id PK
+        BIGINT problem_id FK
+        BIGINT user_id
+        VARCHAR latest_answer_status
+        BIT is_correct
+        BIT counted_as_solved
+        BIT counted_as_correct
+        DATETIME created_at
+        DATETIME updated_at
+    }
+```
+
+## JPA 설계 관점
+
+현재 JPA entity는 객체 연관관계를 최소화하고 FK id 기반으로 설계했습니다.
+
+- `ProblemJpaEntity`는 `ChapterJpaEntity`를 직접 참조하지 않고 `chapterId`만 가집니다.
+- `ProblemChoiceJpaEntity`도 `ProblemJpaEntity` 객체를 잡지 않고 `problemId`만 가집니다.
+
+선택 이유:
+
+- JPA 프록시와 지연 로딩 의존 최소화
+- aggregate 경계 명확화
+- 조회 쿼리 의도를 더 명시적으로 표현
+- `quiz-domain`과 `quiz-infrastructure` 분리 유지
+
+## JPA Entity 생성 방식
+
+현재 JPA Entity는 `builder` 대신 `create()` 또는 의미가 드러나는 정적 팩토리 메서드를 사용했습니다.
+
+예:
+
+- `SolveAttemptJpaEntity.create(...)`
+- `SolveAttemptAnswerJpaEntity.objective(...)`
+- `SolveAttemptAnswerJpaEntity.subjective(...)`
+
+이유:
+
+- JPA Entity는 저장 모델이므로 허용되는 생성 형태를 제한하는 편이 더 안전합니다.
+- 필수값이 빠진 partially initialized object를 줄일 수 있습니다.
+- `builder`보다 `create()`가 어떤 row를 저장하는가를 더 직접적으로 보여줍니다.
+- domain model과 JPA model의 역할 차이를 코드 스타일에서도 유지할 수 있습니다.
+
+## ID 생성 전략
+
+- `Chapter`, `Problem`처럼 요구사항과 시드 데이터에서 직접 식별되는 개체는 assigned id를 사용합니다.
+- `ProblemChoice`, `ProblemAnswerKey`, `SolveAttempt`, `SolveAttemptAnswer`처럼 내부 row 식별이 목적이면 `@GeneratedValue`를 사용합니다.
+- `ProblemStatistics`처럼 특정 문제의 스냅샷 row는 별도 surrogate key 대신 `problem_id` 자체를 PK로 사용합니다.

--- a/docs/architecture/05.API-Design.md
+++ b/docs/architecture/05.API-Design.md
@@ -1,0 +1,143 @@
+# API 설계
+
+## 1. 랜덤 문제 조회
+
+- `POST /api/problems/random`
+
+요청:
+
+```json
+{
+  "chapterId": 1,
+  "userId": 1
+}
+```
+
+응답 예시:
+
+```json
+{
+  "problemId": 1001,
+  "content": "Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.",
+  "choices": ["int", "long", "boolean", "short", "byte"],
+  "answerCorrectRate": 68
+}
+```
+
+규칙:
+
+- 이미 푼 문제 제외
+- 직전에 skip한 문제 제외
+- 남은 문제 중 랜덤 1개 반환
+- 30명 이상 풀이 시 정답률 공개
+- 30명 미만이면 `answerCorrectRate = null`
+
+오류:
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 chapter
+- `409`: 더 이상 출제 가능한 문제 없음
+
+## 2. 문제 넘기기
+
+- `POST /api/problems/skip`
+
+요청:
+
+```json
+{
+  "chapterId": 1,
+  "userId": 1,
+  "problemId": 1001
+}
+```
+
+응답:
+
+- 현재 문제를 `SKIPPED`로 기록
+- 같은 단원에서 다음 랜덤 문제 1개 반환
+
+오류:
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 chapter 또는 해당 chapter에 속하지 않는 problem
+- `409`: skip 이후 더 이상 출제 가능한 문제 없음
+
+## 3. 문제 제출
+
+- `POST /api/problems/submit`
+
+요청:
+
+```json
+{
+  "problemId": 3,
+  "userId": 1,
+  "answerType": "OBJECTIVE",
+  "selectedChoices": [1, 3]
+}
+```
+
+응답 예시:
+
+```json
+{
+  "problemId": 3,
+  "answerType": "OBJECTIVE",
+  "answerStatus": "PARTIAL",
+  "explanation": "정답은 1번과 2번입니다.",
+  "problemAnswers": ["1", "2"]
+}
+```
+
+규칙:
+
+- 객관식/주관식 모두 지원
+- 객관식은 복수 정답 가능
+- 정답/부분 정답/오답 판정
+- 제출 즉시 해설과 정답 반환
+- 제출 이력과 사용자 답안 저장
+
+오류:
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 problem
+- `409`: 문제 답안 형식과 제출 형식 불일치
+
+## 4. 풀었던 문제 상세 조회
+
+- `POST /api/problems/detail`
+
+요청:
+
+```json
+{
+  "userId": 1,
+  "problemId": 3
+}
+```
+
+응답 예시:
+
+```json
+{
+  "problemId": 3,
+  "answerType": "OBJECTIVE",
+  "answerStatus": "PARTIAL",
+  "explanation": "정답은 1번과 2번입니다.",
+  "problemAnswers": ["1", "2"],
+  "userAnswers": ["1", "3"],
+  "answerCorrectRate": 67
+}
+```
+
+규칙:
+
+- 사용자 + 문제 기준 최신 `SOLVED` 이력 조회
+- 정답, 사용자 답안, 해설, 정답률을 함께 반환
+- 풀이 이력이 없으면 예외 처리
+
+오류:
+
+- `400`: 요청 검증 실패
+- `404`: 존재하지 않는 problem 또는 풀이 이력 없음

--- a/docs/architecture/06.Test-Strategy.md
+++ b/docs/architecture/06.Test-Strategy.md
@@ -1,0 +1,61 @@
+# 테스트 전략
+
+현재 테스트는 총 `10개 테스트 클래스`, `51개 테스트 케이스`로 구성했습니다.
+
+- application unit test: `7개 클래스 / 19개 테스트`
+- api slice test: `1개 클래스 / 15개 테스트`
+- infrastructure integration test: `1개 클래스 / 9개 테스트`
+- bootstrap end-to-end test: `1개 클래스 / 8개 테스트`
+
+## 왜 이 테스트가 필요한가
+
+요구사항의 핵심은 단순 CRUD가 아니라 아래 불변식을 지키는 것입니다.
+
+- 랜덤 문제 조회 시 이미 푼 문제와 직전 skip 문제가 제외되는지
+- 문제 제출 시 객관식/주관식 채점과 부분 정답 정책이 정확한지
+- 풀었던 문제 상세 조회 시 사용자 답안, 정답, 정답률이 일관되게 내려가는지
+- 정답률 계산이 `distinct user` 기준으로 유지되는지
+- 같은 문제에 동시 제출이 몰려도 통계가 깨지지 않는지
+- Redis 캐시가 miss/hit 상황 모두에서 올바르게 동작하는지
+
+즉 테스트의 목적은 "정상 응답이 오는가" 수준이 아니라,
+문제 풀이 도메인 규칙, 정답률 집계, 동시성, API 계약이 함께 깨지지 않는지를 계층별로 검증하는 것입니다.
+
+## 계층별 테스트
+
+### application unit test
+
+- `GetRandomProblemServiceTest`
+- `SkipProblemServiceTest`
+- `SubmitProblemAnswerServiceTest`
+- `GetSolvedProblemDetailServiceTest`
+- `ProblemCorrectRateServiceTest`
+- `ProblemStatisticsUpdateServiceTest`
+- `ProblemCorrectRateCacheRefreshServiceTest`
+
+### api slice test
+
+- `@WebMvcTest` 기반 `ProblemControllerTest`
+
+### infrastructure integration test
+
+- `SolvingRepositoryIntegrationTest`
+
+### bootstrap end-to-end test
+
+- `GetRandomProblemEndToEndTest`
+
+## 동시성 테스트
+
+정답률 집계 정합성을 검증하기 위해 아래 시나리오를 추가했습니다.
+
+1. 동일한 문제에 대해 서로 다른 100명의 사용자가 동시에 제출
+- `solve_attempts` 100건 저장
+- `problem_user_statistics` 100건 생성
+- `problem_statistics.solved_user_count == 100`
+- `correct_user_count`, `correct_rate` 일관성 유지
+
+2. 동일한 문제에 대해 동일한 사용자가 동시에 여러 번 제출
+- `solve_attempts` 히스토리는 여러 건 저장
+- `problem_user_statistics`는 `(problem_id, user_id)` 기준 1건 유지
+- `problem_statistics.solved_user_count`는 1만 증가

--- a/docs/report/01.CorrectRate-Concurrency-Report.md
+++ b/docs/report/01.CorrectRate-Concurrency-Report.md
@@ -1,0 +1,97 @@
+# 정답률 계산과 경쟁 상태 분석
+
+## 배경
+
+정답률 계산은 과제의 핵심 로직입니다. 조회 시마다 `solve_attempts`를 직접 집계하면 정답률 계산이 SQL에 묻히고 읽기 비용도 커진다고 판단했습니다.
+
+현재 구현은:
+
+- 제출 시 `problem_user_statistics`, `problem_statistics` 갱신
+- 조회 시 Redis 캐시 우선
+- cache miss 시 `problem_statistics` 조회
+
+구조를 사용합니다.
+
+## 검토한 방향
+
+1. DB 집계 쿼리
+- 구현은 단순하지만 트래픽 증가 시 병목 우려
+
+2. DB + Redis 읽기
+- 현재 채택
+- MySQL이 기준 저장소, Redis가 조회 캐시 역할
+
+3. 비동기 + Redis 활용
+- 응답시간 개선 가능
+- 대신 최종적 일관성 모델과 멱등성 설계 필요
+
+4. 백그라운드 집계 배치
+- 현재는 submit 대체가 아니라 Redis 재동기화/복구용 보조 배치로 사용
+
+5. Kafka 기반 비동기 집계
+- 확장성은 좋지만 과제 범위를 넘어서는 운영 복잡도 발생
+
+## 현재 구조
+
+- `solve_attempts`
+  - 제출 이력 저장
+- `problem_user_statistics`
+  - `(problem_id, user_id)` 기준 최초 제출 여부 판정
+- `problem_statistics`
+  - `problem_id` 기준 정답률 스냅샷
+- Redis
+  - `problem:correct-rate:{problemId}` 캐시
+
+## 현재 경쟁 상태가 발생하는 지점
+
+현재 경쟁 상태는 두 단계로 나뉩니다.
+
+1. `problem_user_statistics`
+- 같은 `(problemId, userId)`로 중복 제출이 동시에 들어올 수 있으므로,
+  unique key 기준으로 최초 제출 여부를 판정합니다.
+- 이 단계는 동일 사용자의 중복 집계를 막기 위한 경쟁 제어 지점입니다.
+
+2. `problem_statistics`
+- 같은 `problemId`에 대해 여러 사용자의 제출이 동시에 몰릴 수 있으므로,
+  `findStatisticsForUpdate(problemId)`로 `problem_statistics` row를 잠그고
+  `solved_user_count`, `correct_user_count`, `correct_rate`를 갱신합니다.
+- 현재 구조에서 실제 병목이 가장 잘 드러나는 지점은 이 row lock 획득 구간입니다.
+
+즉 현재 경쟁 상태는
+- `(problemId, userId)` 기준 중복 집계 방지
+- `problemId` 기준 통계 row 갱신 직렬화
+두 형태로 나뉘어 발생합니다.
+
+## Atomic 타입을 사용하지 않은 이유
+
+`ProblemStatistics.applyFirstSolved()` 내부에서는 `solvedUserCount += 1`, `correctUserCount += 1`를 사용합니다.
+여기서 `AtomicInteger`/`AtomicLong`를 쓰는 방향은 적절하지 않다고 판단했습니다.
+
+이유:
+
+- 현재 경쟁 상태는 JVM 메모리 안의 공유 변수 경쟁이 아니라 DB row 갱신 경쟁입니다.
+- 정합성은 Java atomic 타입이 아니라 `problem_statistics` row lock과 트랜잭션이 보장합니다.
+- `AtomicInteger`는 단일 JVM 메모리 객체 경쟁에는 유효하지만, DB 기반 경쟁이나 다중 인스턴스 환경에는 충분하지 않습니다.
+
+즉 여기서 중요한 것은 원자 타입이 아니라:
+
+- unique key
+- DB row lock
+- 트랜잭션
+- 이후 비동기/Redis 집계 전환 가능성
+
+입니다.
+
+## 동시성 검증
+
+현재 구조가 실제로 정합성을 지키는지 아래 시나리오로 검증했습니다.
+
+1. 동일한 문제에 대해 서로 다른 100명의 사용자가 동시에 제출
+2. 동일한 문제에 대해 동일한 사용자가 동시에 여러 번 제출
+
+이 테스트를 통해:
+
+- hot problem 동시 제출
+- distinct user 기준 집계
+
+라는 두 가지 핵심 불변식이 깨지지 않는지를 확인했습니다.

--- a/docs/report/02.Cache-and-Batch-Report.md
+++ b/docs/report/02.Cache-and-Batch-Report.md
@@ -1,0 +1,56 @@
+# 캐시 전략과 배치 재동기화
+
+## 현재 캐시 전략
+
+현재 정답률 조회는 Redis를 사용하는 `cache-aside + write-through` 방식으로 구성했습니다.
+
+### 조회
+
+- 먼저 Redis에서 `problem:correct-rate:{problemId}` 키 조회
+- cache hit면 바로 반환
+- cache miss면 `problem_statistics`를 읽고 `ProblemCorrectRatePolicy`를 적용한 뒤 Redis에 다시 저장
+
+### 제출
+
+- `problem_statistics`, `problem_user_statistics`를 갱신한 뒤 Redis에도 같은 값을 즉시 반영
+
+### null 정답률
+
+- 30명 미만 풀이 문제는 `NULL` sentinel 값으로 저장해 cache penetration을 줄였습니다.
+
+### 장애 대응
+
+- Redis 예외가 발생해도 DB fallback으로 동작하도록 했습니다.
+
+## 이 전략을 선택한 이유
+
+- 정답률은 조회 빈도가 높고 계산 규칙이 명확해 캐시 효율이 높습니다.
+- submit 시 DB 기준 정합성을 유지하면서도 조회는 Redis에서 빠르게 처리할 수 있습니다.
+- 과제 범위에서 설명 가능성과 성능 개선 가능성의 균형이 좋습니다.
+
+## 배치 재동기화
+
+현재 배치는 submit 경로를 대체하는 집계 방식이 아니라,
+Redis 캐시 재동기화와 복구를 위한 보조 배치입니다.
+
+동작:
+
+- 스케줄러가 주기적으로 `problem_statistics` 전체 조회
+- 각 `problemId`의 `correctRate`를 Redis에 다시 반영
+
+목적:
+
+- Redis 장애 후 캐시 복구
+- cache miss가 많아진 상황에서 warm-up
+- MySQL 기준 값과 Redis 값의 장기 재동기화
+
+## 한계
+
+- 현재 배치는 Redis 재동기화/복구에는 유용하지만 submit 경로의 병목 자체를 줄여주지는 않습니다.
+- submit 성능 자체를 줄이려면 결국 통계 갱신을 request path 밖으로 옮기는 비동기 구조가 필요합니다.
+
+## 향후 확장 방향
+
+- 정답률 갱신 비동기화
+- Redis write-through에서 event-driven 집계로 확장
+- 배치 재동기화에서 변경분만 갱신하는 증분 방식으로 발전

--- a/docs/report/03.Load-Test-Report.md
+++ b/docs/report/03.Load-Test-Report.md
@@ -1,0 +1,56 @@
+# 성능 테스트 보고서
+
+## 성능 테스트 환경
+
+성능 테스트는 `k6 + Prometheus + Grafana` 조합으로 구성했습니다.
+
+구성:
+
+- `Prometheus`: k6 remote write 결과 수집
+- `Grafana`: 성능 지표 시각화
+- `k6`: 컨테이너 기반 부하 생성
+- `app /actuator/prometheus`: 애플리케이션 메트릭 수집
+- `perf/k6/*.js`: API별 부하 테스트 스크립트
+- `perf/RESULTS.md`: 실행 규칙과 결과 수집 포맷
+
+실행:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.perf.yml up --build -d
+```
+
+## 주요 스크립트
+
+- `perf/k6/random.js`: 랜덤 조회
+- `perf/k6/submit.js`: 제출 집중 부하
+- `perf/k6/detail.js`: 상세 조회
+- `perf/k6/mixed.js`: 혼합 부하
+
+## submit hot problem 결과 요약
+
+시나리오:
+
+- 대상 API: `POST /api/problems/submit`
+- 대상 문제: `problemId=1002`
+- 부하: 2분 동안 초당 20건
+- 목적: 같은 문제에 제출이 집중될 때 정답률 통계 갱신 구간이 병목이 되는지 확인
+
+결과 요약:
+
+| 회차 | 결과 | p95 | p99 | avg | 실패율 | 처리량 |
+|---|---|---:|---:|---:|---:|---:|
+| 1차 | 실패 | 22.94ms | 109.44ms | 15.45ms | 1.37% | 19.97 req/s |
+| 2차 | 성공 | 18.50ms | 25.22ms | 11.11ms | 0.00% | 19.97 req/s |
+| 3차 | 성공 | 18.78ms | 26.39ms | 11.70ms | 0.41% | 19.97 req/s |
+
+## 해석
+
+- 1차 실패 원인은 애플리케이션 병목이 아니라 테스트 시작 직후 일부 요청이 `connection refused`로 실패한 readiness 문제였습니다.
+- readiness가 보장된 2차, 3차에서는 실패율이 0% 또는 1% 미만으로 안정화되었습니다.
+- 정상 측정 구간 기준 `submit` API는 `p95 약 18~19ms`, `p99 약 25~26ms` 수준으로 매우 빠르게 응답했습니다.
+- 현재 구조에서는 같은 문제로 submit 부하를 몰아도 정답률 통계 갱신이 즉시 병목으로 드러나지는 않았습니다.
+
+## 결론
+
+- 현재 Redis 읽기 캐시 + DB 기준 통계 갱신 구조는 submit hot problem 시나리오에서 충분히 안정적으로 동작했습니다.
+- 다만 이 결과는 초당 20건 수준의 기준선이며, 더 높은 쓰기 부하나 다중 인스턴스 환경에서는 비동기 집계 구조를 추가로 검토할 수 있습니다.


### PR DESCRIPTION
## 요약
  - 루트 README를 간결한 안내 페이지로 재작성했습니다.
  - 설계 문서는 docs/architecture, 보고서는 docs/report로 분리했습니다.
  - 문서 번호 체계와 링크 네이밍을 통일했습니다.
  - 성능 테스트 실행 명령과 seed 기준 파라미터도 문서에 정리했습니다.