### PR TITLE
[Docs] 문서 가독성 개선 및 Mermaid 다이어그램 보강

### DIFF
--- a/docs/architecture/01.Architecture-Overview.md
+++ b/docs/architecture/01.Architecture-Overview.md
@@ -21,6 +21,49 @@ root
 └── quiz-infrastructure
 ```
 
+```mermaid
+flowchart LR
+    user["User"]
+
+    subgraph bootstrap["quiz-bootstrap"]
+        app["Spring Boot App<br/>실행 / 조립 / scheduling"]
+    end
+
+    subgraph api["quiz-api"]
+        controller["ProblemController<br/>request / response / validation"]
+    end
+
+    subgraph application["quiz-application"]
+        usecase["Use Case Service<br/>random / skip / submit / detail"]
+        statsService["Statistics Service<br/>correct rate / cache refresh"]
+    end
+
+    subgraph domain["quiz-domain"]
+        problemDomain["Problem / AnswerKey"]
+        solvingDomain["SolvedProblem / UserChapterSolvingState"]
+        statsDomain["ProblemStatistics / CorrectRatePolicy"]
+    end
+
+    subgraph infrastructure["quiz-infrastructure"]
+        repository["JPA / Redis Repository Impl"]
+    end
+
+    mysql["MySQL"]
+    redis["Redis"]
+
+    user --> controller
+    app --> controller
+    controller --> usecase
+    usecase --> problemDomain
+    usecase --> solvingDomain
+    usecase --> statsService
+    statsService --> statsDomain
+    usecase --> repository
+    statsService --> repository
+    repository --> mysql
+    repository --> redis
+```
+
 ### `quiz-bootstrap`
 
 - `@SpringBootApplication`

--- a/docs/architecture/02.Domain-Design.md
+++ b/docs/architecture/02.Domain-Design.md
@@ -2,7 +2,7 @@
 
 ## DDD 학습과 적용
 
-<img src="../images/ddd_image.png" alt="ddd overview" width="400" />
+<img src="../images/ddd_structure.png" alt="ddd overview" width="1129" />
 
 이번 과제에서는 DDD를 학습하면서 아래 기준을 의식해 구조를 정리했습니다.
 

--- a/docs/architecture/06.Test-Strategy.md
+++ b/docs/architecture/06.Test-Strategy.md
@@ -50,12 +50,50 @@
 정답률 집계 정합성을 검증하기 위해 아래 시나리오를 추가했습니다.
 
 1. 동일한 문제에 대해 서로 다른 100명의 사용자가 동시에 제출
+
+```mermaid
+flowchart TD
+    users["서로 다른 100명의 사용자"]
+    submit["동일 problemId로 동시에 submit"]
+    attempt["solve_attempts 100건 저장"]
+    userStats["problem_user_statistics 100건 생성<br/>(problem_id, user_id) 기준 1건씩"]
+    stats["problem_statistics row 갱신<br/>solved_user_count / correct_user_count / correct_rate"]
+    verify["최종 검증<br/>attempts = 100<br/>user_statistics = 100<br/>solved_user_count = 100"]
+
+    users --> submit
+    submit --> attempt
+    submit --> userStats
+    userStats --> stats
+    attempt --> verify
+    userStats --> verify
+    stats --> verify
+```
+
 - `solve_attempts` 100건 저장
 - `problem_user_statistics` 100건 생성
 - `problem_statistics.solved_user_count == 100`
 - `correct_user_count`, `correct_rate` 일관성 유지
 
 2. 동일한 문제에 대해 동일한 사용자가 동시에 여러 번 제출
+
+```mermaid
+flowchart TD
+    user["동일한 1명의 사용자"]
+    submit["동일 problemId로 동시에 여러 번 submit"]
+    attempt["solve_attempts 히스토리는 여러 건 저장 가능"]
+    duplicate["problem_user_statistics는<br/>(problem_id, user_id) unique 기준 1건 유지"]
+    stats["problem_statistics는 최초 1회만 집계<br/>solved_user_count는 1만 증가"]
+    verify["최종 검증<br/>attempts = 여러 건<br/>user_statistics = 1<br/>solved_user_count = 1"]
+
+    user --> submit
+    submit --> attempt
+    submit --> duplicate
+    duplicate --> stats
+    attempt --> verify
+    duplicate --> verify
+    stats --> verify
+```
+
 - `solve_attempts` 히스토리는 여러 건 저장
 - `problem_user_statistics`는 `(problem_id, user_id)` 기준 1건 유지
 - `problem_statistics.solved_user_count`는 1만 증가

--- a/docs/report/01.CorrectRate-Concurrency-Report.md
+++ b/docs/report/01.CorrectRate-Concurrency-Report.md
@@ -15,21 +15,58 @@
 ## 검토한 방향
 
 1. DB 집계 쿼리
-- 구현은 단순하지만 트래픽 증가 시 병목 우려
+- 가장 먼저 떠올린 방법은 조회 시마다 `solve_attempts`를 직접 집계하는 방식이었습니다.
+- 장점:
+  - 별도 통계 테이블 없이도 구현 가능
+  - 데이터 정합성을 설명하기 쉽고 모델이 단순합니다.
+- 단점:
+  - 정답률 조회가 잦아질수록 집계 SQL 비용이 그대로 읽기 경로에 남습니다.
+  - `distinct user` 기준 정답률, 부분 정답 정책, 동일 사용자 중복 제출 제외 같은 규칙이 SQL 안으로 깊게 들어가 가독성이 떨어집니다.
+  - random/detail 조회마다 집계가 수행되면 읽기 API 성능이 쉽게 흔들릴 수 있습니다.
+- 따라서 "구현은 쉽지만 조회 성능과 설명 가능성이 함께 나빠질 수 있다"는 이유로 최종 선택하지 않았습니다.
 
 2. DB + Redis 읽기
 - 현재 채택
-- MySQL이 기준 저장소, Redis가 조회 캐시 역할
+- MySQL이 기준 저장소이고, Redis는 조회 캐시 역할을 맡는 구조입니다.
+- 선택 이유:
+  - 정합성은 DB가 책임지고, 읽기 성능은 Redis가 담당하도록 역할을 분리할 수 있습니다.
+  - `problem_statistics`를 스냅샷 테이블로 두면 조회 시 복잡한 집계를 반복하지 않아도 됩니다.
+  - Redis 장애가 나도 DB fallback으로 기능을 유지할 수 있어 설명과 운영 모두 무리가 적습니다.
+- trade-off:
+  - submit 시 통계 테이블을 함께 갱신해야 하므로 쓰기 경로는 단순하지 않습니다.
+  - 같은 `problemId` submit이 몰리면 `problem_statistics` row lock 경합이 생길 수 있습니다.
+- 과제 범위에서는 "정합성, 성능, 구현 복잡도"의 균형이 좋다고 판단해 이 방향을 채택했습니다.
 
 3. 비동기 + Redis 활용
-- 응답시간 개선 가능
-- 대신 최종적 일관성 모델과 멱등성 설계 필요
+- submit 요청에서 통계 갱신을 분리하면 응답시간을 줄일 수 있으므로 자연스럽게 검토한 방향입니다.
+- 기대 효과:
+  - 현재 submit 경로의 병목인 통계 갱신을 사용자 요청이 응답을 기다리는 동기 처리 구간에서 빼낼 수 있습니다.
+    - 왜냐하면 문제 제출 로직과 통계 갱신 로직은 서로 의존성이 없다고 판단했기 때문입니다.
+  - hot problem submit 상황에서 응답속도를 더 안정적으로 만들 가능성이 있습니다.
+- 고민한 지점:
+  - 정답률이 즉시 반영되지 않는 최종적 일관성 모델을 받아들여야 합니다.
+  - 단순히 Redis write-through만 비동기로 빼는 것으로는 핵심 병목이 충분히 줄지 않을 수 있습니다.
+- 따라서 방향성 자체는 유효하지만, 현재 과제 범위에서는 "다음 단계 확장안"으로 두었습니다.
 
 4. 백그라운드 집계 배치
-- 현재는 submit 대체가 아니라 Redis 재동기화/복구용 보조 배치로 사용
+- 정답률 도메인상 실시간성이 아주 중요하지 않다고 판단하여, submit 경로 밖에서 주기적으로 집계하거나 Redis를 다시 채우는 구조도 검토했습니다.
+- 장점:
+  - 설명이 단순하고 운영 제어가 쉽습니다.
+  - Redis 유실, warm-up, 장기 재동기화에 적합합니다.
+- 한계:
+  - submit 직후 최신 정답률이 바로 반영되지 않을 수 있습니다.
+  - 현재 submit 경로의 동기 통계 갱신을 그대로 두면, 배치만 추가해서는 병목이 크게 줄지 않습니다.
+- 그래서 현재 배치는 "submit 대체 집계"가 아니라 "Redis 재동기화/복구용 보조 배치"로만 두었습니다.
 
 5. Kafka 기반 비동기 집계
-- 확장성은 좋지만 과제 범위를 넘어서는 운영 복잡도 발생
+- 가장 확장성이 큰 방향은 이벤트 기반 비동기 집계입니다. problem_id 를 파티션 key 로 하여 진행을 고려했습니다.
+- 장점:
+  - submit과 통계 집계를 완전히 분리할 수 있습니다.
+  - 트래픽이 더 커져도 확장 전략을 설명하기 좋습니다.
+- 단점:
+  - 메시지 브로커 운영, consumer 재처리, 순서 보장, 장애 대응까지 함께 설계해야 합니다.
+  - 현재 과제의 구현 범위와 검증 범위를 넘어서는 복잡도가 생깁니다.
+- 따라서 보고서에서는 장기 확장 방향으로만 언급하고, 현재 구현 대상에서는 제외했습니다.
 
 ## 현재 구조
 
@@ -42,9 +79,58 @@
 - Redis
   - `problem:correct-rate:{problemId}` 캐시
 
+## submit 정답률 갱신 흐름
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant SubmitService as SubmitProblemAnswerService
+    participant SolveAttemptRepo as solve_attempts
+    participant StatsService as ProblemStatisticsUpdateService
+    participant UserStats as problem_user_statistics
+    participant ProblemStats as problem_statistics
+    participant Redis
+
+    User->>SubmitService: submit(problemId, userId, answer)
+    SubmitService->>SolveAttemptRepo: 제출 이력 저장
+    SubmitService->>StatsService: recordSolvedProblem(problemId, userId, answerStatus)
+    StatsService->>UserStats: trySaveFirstSolved(problemId, userId, answerStatus)
+
+    alt 최초 제출 사용자
+        StatsService->>ProblemStats: findStatisticsForUpdate(problemId)
+        Note over ProblemStats: problem_statistics row lock
+        StatsService->>ProblemStats: solved/correct/rate 갱신
+        StatsService->>Redis: correct rate write-through
+    else 이미 집계된 사용자
+        StatsService->>UserStats: latestAnswerStatus만 갱신
+    end
+
+    SubmitService-->>User: 제출 결과 응답
+```
+
 ## 현재 경쟁 상태가 발생하는 지점
 
 현재 경쟁 상태는 두 단계로 나뉩니다.
+
+## same problem submit contention point
+
+```mermaid
+flowchart TD
+    requests["여러 요청이 동일 problemId로 동시에 submit"]
+    firstGate["problem_user_statistics<br/>최초 제출 여부 판정"]
+    duplicate["동일 user 중복 제출은<br/>unique key 기준으로 차단"]
+    lock["findStatisticsForUpdate(problemId)"]
+    wait["같은 problemId 요청은<br/>problem_statistics row lock 대기"]
+    update["solved_user_count / correct_user_count / correct_rate 갱신"]
+    commit["트랜잭션 커밋 후 다음 요청 진행"]
+
+    requests --> firstGate
+    firstGate -->|동일 user 중복| duplicate
+    firstGate -->|최초 제출 사용자| lock
+    lock --> wait
+    wait --> update
+    update --> commit
+```
 
 1. `problem_user_statistics`
 - 같은 `(problemId, userId)`로 중복 제출이 동시에 들어올 수 있으므로,

--- a/docs/report/02.Cache-and-Batch-Report.md
+++ b/docs/report/02.Cache-and-Batch-Report.md
@@ -6,11 +6,47 @@
 
 ### 조회
 
+```mermaid
+flowchart TD
+    user["User"]
+    readApi["random / detail 조회"]
+    redis["Redis<br/>problem:correct-rate:{problemId}"]
+    hit["cache hit<br/>바로 반환"]
+    miss["cache miss"]
+    db["MySQL<br/>problem_statistics 조회"]
+    refill["Redis에 다시 저장"]
+    response["정답률 응답"]
+
+    user --> readApi
+    readApi --> redis
+    redis -->|hit| hit
+    redis -->|miss| miss
+    miss --> db
+    db --> refill
+    refill --> response
+    hit --> response
+```
+
 - 먼저 Redis에서 `problem:correct-rate:{problemId}` 키 조회
 - cache hit면 바로 반환
 - cache miss면 `problem_statistics`를 읽고 `ProblemCorrectRatePolicy`를 적용한 뒤 Redis에 다시 저장
 
 ### 제출
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant SubmitApi as submit API
+    participant MySQL as MySQL
+    participant Redis as Redis
+
+    User->>SubmitApi: submit(problemId, userId, answer)
+    SubmitApi->>MySQL: solve_attempts 저장
+    SubmitApi->>MySQL: problem_user_statistics 갱신
+    SubmitApi->>MySQL: problem_statistics 갱신
+    SubmitApi->>Redis: correct rate write-through
+    SubmitApi-->>User: 제출 결과 응답
+```
 
 - `problem_statistics`, `problem_user_statistics`를 갱신한 뒤 Redis에도 같은 값을 즉시 반영
 
@@ -33,9 +69,21 @@
 현재 배치는 submit 경로를 대체하는 집계 방식이 아니라,
 Redis 캐시 재동기화와 복구를 위한 보조 배치입니다.
 
+```mermaid
+flowchart TD
+    scheduler["ProblemCorrectRateBatchScheduler"]
+    db["MySQL<br/>problem_statistics 전체 조회"]
+    refresh["problemId별 correctRate 재적재"]
+    redis["Redis 갱신"]
+
+    scheduler --> db
+    db --> refresh
+    refresh --> redis
+```
+
 동작:
 
-- 스케줄러가 주기적으로 `problem_statistics` 전체 조회
+- `ProblemCorrectRateBatchScheduler` 스케줄러가 주기적으로 `problem_statistics` 전체 조회
 - 각 `problemId`의 `correctRate`를 Redis에 다시 반영
 
 목적:


### PR DESCRIPTION
## 요약
  architecture/report 문서 전반의 가독성을 높이기 위해 Mermaid 다이어그램을 추가하고,
  정답률 계산과 경쟁 상태 분석 문서의 설명을 보강했습니다.

  ## 변경 사항
  - Architecture Overview에 흐름 관점 아키텍처 다이어그램 추가
  - Test Strategy에 동시성 테스트 flowchart 2개 추가
  - CorrectRate Concurrency Report에
    - submit 정답률 갱신 sequence diagram
    - same problem submit contention flowchart
    - 검토한 방향 설명 보강
  - Cache and Batch Report에
    - cache-aside 조회 흐름 flowchart
    - write-through submit 갱신 sequence diagram
    - batch refresh 보조 flowchart
    추가

  ## 기대 효과
  - 멀티 모듈 흐름을 구조적으로 이해하기 쉬워짐
  - 동시성 테스트 의도와 검증 포인트가 명확해짐
  - 정답률 경쟁 상태와 병목 지점이 더 직관적으로 보임
  - 캐시 전략과 배치 역할 구분이 쉬워짐