### PR TITLE
[Feat] 문제 제출 입력 검증 및 선택지 유효성 검증 보강

### DIFF
--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.project.quiz.api.common;
 
 import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.InvalidProblemChoiceException;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
 import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
@@ -45,6 +46,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleProblemAnswerTypeMismatch(ProblemAnswerTypeMismatchException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse("PROBLEM_ANSWER_TYPE_MISMATCH", exception.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidProblemChoiceException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidProblemChoice(InvalidProblemChoiceException exception) {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse("INVALID_PROBLEM_CHOICE", exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidator.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidator.java
@@ -4,6 +4,8 @@ import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import java.util.HashSet;
+
 public class SubmitProblemAnswerRequestValidator implements ConstraintValidator<ValidSubmitProblemAnswerRequest, SubmitProblemAnswerRequest> {
 
     @Override
@@ -21,7 +23,29 @@ public class SubmitProblemAnswerRequestValidator implements ConstraintValidator<
                         .addConstraintViolation();
                 return false;
             }
+
+            if (value.subjectiveAnswer() != null && !value.subjectiveAnswer().isBlank()) {
+                context.buildConstraintViolationWithTemplate("subjectiveAnswer must be blank for OBJECTIVE answerType")
+                        .addPropertyNode("subjectiveAnswer")
+                        .addConstraintViolation();
+                return false;
+            }
+
+            if (value.selectedChoices().size() != new HashSet<>(value.selectedChoices()).size()) {
+                context.buildConstraintViolationWithTemplate("selectedChoices must not contain duplicates")
+                        .addPropertyNode("selectedChoices")
+                        .addConstraintViolation();
+                return false;
+            }
+
             return true;
+        }
+
+        if (value.selectedChoices() != null && !value.selectedChoices().isEmpty()) {
+            context.buildConstraintViolationWithTemplate("selectedChoices must be empty for SUBJECTIVE answerType")
+                    .addPropertyNode("selectedChoices")
+                    .addConstraintViolation();
+            return false;
         }
 
         if (value.subjectiveAnswer() == null || value.subjectiveAnswer().isBlank()) {

--- a/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.quiz.api.TestApiApplication;
 import com.project.quiz.api.common.GlobalExceptionHandler;
 import com.project.quiz.application.solving.exception.ChapterNotFoundException;
+import com.project.quiz.application.solving.exception.InvalidProblemChoiceException;
 import com.project.quiz.application.solving.exception.NoAvailableProblemException;
 import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
@@ -279,5 +280,51 @@ class ProblemControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
                 .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must not be blank for SUBJECTIVE answerType"));
+    }
+
+    @Test
+    @DisplayName("객관식 제출에서 주관식 답안이 같이 오면 400을 반환한다")
+    void returnBadRequestWhenObjectiveContainsSubjectiveAnswer() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), "text"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must be blank for OBJECTIVE answerType"));
+    }
+
+    @Test
+    @DisplayName("주관식 제출에서 객관식 선택지가 같이 오면 400을 반환한다")
+    void returnBadRequestWhenSubjectiveContainsSelectedChoices() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, List.of(1), "answer"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must be empty for SUBJECTIVE answerType"));
+    }
+
+    @Test
+    @DisplayName("객관식 제출에서 중복 선택지가 오면 400을 반환한다")
+    void returnBadRequestWhenObjectiveContainsDuplicateChoices() throws Exception {
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 1), null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must not contain duplicates"));
+    }
+
+    @Test
+    @DisplayName("문제 제출에서 존재하지 않는 선택지 번호면 400을 반환한다")
+    void returnBadRequestWhenProblemChoiceInvalid() throws Exception {
+        when(submitProblemAnswerService.submit(any()))
+                .thenThrow(new InvalidProblemChoiceException(1001L, List.of(7)));
+
+        mockMvc.perform(post("/api/problems/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(7), null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PROBLEM_CHOICE"));
     }
 }

--- a/quiz-api/src/test/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidatorTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/problem/SubmitProblemAnswerRequestValidatorTest.java
@@ -1,0 +1,53 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubmitProblemAnswerRequestValidatorTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void objectiveRequestRejectsDuplicateChoices() {
+        Set<ConstraintViolation<SubmitProblemAnswerRequest>> violations = validator.validate(
+                new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 1), null)
+        );
+
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .contains("selectedChoices must not contain duplicates");
+    }
+
+    @Test
+    void objectiveRequestRejectsSubjectiveAnswer() {
+        Set<ConstraintViolation<SubmitProblemAnswerRequest>> violations = validator.validate(
+                new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 2), "text")
+        );
+
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .contains("subjectiveAnswer must be blank for OBJECTIVE answerType");
+    }
+
+    @Test
+    void subjectiveRequestRejectsSelectedChoices() {
+        Set<ConstraintViolation<SubmitProblemAnswerRequest>> violations = validator.validate(
+                new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, List.of(1), "answer")
+        );
+
+        assertThat(violations).extracting(ConstraintViolation::getMessage)
+                .contains("selectedChoices must be empty for SUBJECTIVE answerType");
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/exception/InvalidProblemChoiceException.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/exception/InvalidProblemChoiceException.java
@@ -1,0 +1,10 @@
+package com.project.quiz.application.solving.exception;
+
+import java.util.List;
+
+public class InvalidProblemChoiceException extends RuntimeException {
+
+    public InvalidProblemChoiceException(Long problemId, List<Integer> invalidChoices) {
+        super("Invalid choice sequence for problemId=%d: %s".formatted(problemId, invalidChoices));
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/solving/service/SubmitProblemAnswerService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/solving/service/SubmitProblemAnswerService.java
@@ -1,5 +1,6 @@
 package com.project.quiz.application.solving.service;
 
+import com.project.quiz.application.solving.exception.InvalidProblemChoiceException;
 import com.project.quiz.application.statistics.service.ProblemStatisticsUpdateService;
 import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.exception.ProblemNotFoundInChapterException;
@@ -8,13 +9,16 @@ import com.project.quiz.application.solving.model.SubmitProblemAnswerResult;
 import com.project.quiz.application.solving.repository.ProblemRepository;
 import com.project.quiz.application.solving.repository.SolveAttemptRepository;
 import com.project.quiz.domain.problem.Problem;
+import com.project.quiz.domain.problem.ProblemAnswerFormat;
 import com.project.quiz.domain.solving.GradingResult;
 import com.project.quiz.domain.solving.SubmittedAnswer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +45,8 @@ public class SubmitProblemAnswerService {
                 command.subjectiveAnswer()
         );
 
+        validateSelectedChoices(problem, submittedAnswer);
+
         GradingResult gradingResult = problem.grade(submittedAnswer);
 
         solveAttemptRepository.saveSolvedAttempt(
@@ -63,5 +69,23 @@ public class SubmitProblemAnswerService {
                 gradingResult.explanation(),
                 gradingResult.problemAnswers()
         );
+    }
+
+    private void validateSelectedChoices(Problem problem, SubmittedAnswer submittedAnswer) {
+        if (problem.answerFormat() != ProblemAnswerFormat.OBJECTIVE || submittedAnswer.selectedChoices() == null) {
+            return;
+        }
+
+        Set<Integer> availableChoices = problem.choices().stream()
+                .map(choice -> choice.sequence())
+                .collect(java.util.stream.Collectors.toSet());
+
+        List<Integer> invalidChoices = submittedAnswer.selectedChoices().stream()
+                .filter(choice -> !availableChoices.contains(choice))
+                .toList();
+
+        if (!invalidChoices.isEmpty()) {
+            throw new InvalidProblemChoiceException(problem.id(), invalidChoices);
+        }
     }
 }

--- a/quiz-application/src/test/java/com/project/quiz/application/solving/service/SubmitProblemAnswerServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/solving/service/SubmitProblemAnswerServiceTest.java
@@ -1,6 +1,7 @@
 package com.project.quiz.application.solving.service;
 
 import com.project.quiz.application.statistics.service.ProblemStatisticsUpdateService;
+import com.project.quiz.application.solving.exception.InvalidProblemChoiceException;
 import com.project.quiz.application.solving.exception.ProblemAnswerTypeMismatchException;
 import com.project.quiz.application.solving.model.SubmitProblemAnswerCommand;
 import com.project.quiz.application.solving.model.SubmitProblemAnswerResult;
@@ -24,6 +25,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +78,8 @@ class SubmitProblemAnswerServiceTest {
     void objectivePartialAnswerReturnsPartial() {
         Problem problem = new Problem(
                 100L, 1L, "problem", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER,
-                List.of(), new ProblemAnswerKey(Set.of(1, 2), List.of()), "해설"
+                List.of(new ProblemChoice(1, "a"), new ProblemChoice(2, "b"), new ProblemChoice(3, "c")),
+                new ProblemAnswerKey(Set.of(1, 2), List.of()), "해설"
         );
         when(problemRepository.findById(100L)).thenReturn(Optional.of(problem));
 
@@ -113,5 +116,33 @@ class SubmitProblemAnswerServiceTest {
         assertThatThrownBy(() -> submitProblemAnswerService.submit(
                 new SubmitProblemAnswerCommand(200L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null)
         )).isInstanceOf(ProblemAnswerTypeMismatchException.class);
+    }
+
+    @Test
+    void invalidObjectiveChoiceThrowsException() {
+        Problem problem = new Problem(
+                100L, 1L, "problem", ProblemAnswerFormat.OBJECTIVE, ProblemType.MULTIPLE_ANSWER,
+                List.of(new ProblemChoice(1, "a"), new ProblemChoice(2, "b")),
+                new ProblemAnswerKey(Set.of(1, 2), List.of()),
+                "해설"
+        );
+        when(problemRepository.findById(100L)).thenReturn(Optional.of(problem));
+
+        assertThatThrownBy(() -> submitProblemAnswerService.submit(
+                new SubmitProblemAnswerCommand(100L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null)
+        )).isInstanceOf(InvalidProblemChoiceException.class);
+
+        verify(solveAttemptRepository, never()).saveSolvedAttempt(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        );
+        verify(problemStatisticsUpdateService, never()).recordSolvedProblem(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.any()
+        );
     }
 }


### PR DESCRIPTION
## 요약
  문제 제출 API의 입력 검증을 보강했습니다.

  ## 변경 사항
  - 객관식인데 subjectiveAnswer가 같이 오는 요청 차단
  - 주관식인데 selectedChoices가 같이 오는 요청 차단
  - 객관식 중복 선택지 차단
  - 문제별 실제 선택지 범위를 벗어난 제출 차단
  - 관련 validator, service, controller 테스트 추가/보강

  ## 검증
  ```bash
  ./gradlew :quiz-api:test --tests '*SubmitProblemAnswerRequestValidatorTest' --tests '*ProblemControllerTest' :quiz-application:test --tests '*SubmitProblemAnswerServiceTest'