### PR TITLE
feat: API 공통 응답(CommonResponse) 도입

### DIFF
--- a/docs/architecture/05.API-Design.md
+++ b/docs/architecture/05.API-Design.md
@@ -17,10 +17,14 @@
 
 ```json
 {
-  "problemId": 1001,
-  "content": "Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.",
-  "choices": ["int", "long", "boolean", "short", "byte"],
-  "answerCorrectRate": 68
+  "success": true,
+  "data": {
+    "problemId": 1001,
+    "content": "Java에서 기본형 중 정수 타입이 아닌 것을 고르세요.",
+    "choices": ["int", "long", "boolean", "short", "byte"],
+    "answerCorrectRate": 68
+  },
+  "error": null
 }
 ```
 
@@ -82,11 +86,15 @@
 
 ```json
 {
-  "problemId": 3,
-  "answerType": "OBJECTIVE",
-  "answerStatus": "PARTIAL",
-  "explanation": "정답은 1번과 2번입니다.",
-  "problemAnswers": ["1", "2"]
+  "success": true,
+  "data": {
+    "problemId": 3,
+    "answerType": "OBJECTIVE",
+    "answerStatus": "PARTIAL",
+    "explanation": "정답은 1번과 2번입니다.",
+    "problemAnswers": ["1", "2"]
+  },
+  "error": null
 }
 ```
 
@@ -121,13 +129,30 @@
 
 ```json
 {
-  "problemId": 3,
-  "answerType": "OBJECTIVE",
-  "answerStatus": "PARTIAL",
-  "explanation": "정답은 1번과 2번입니다.",
-  "problemAnswers": ["1", "2"],
-  "userAnswers": ["1", "3"],
-  "answerCorrectRate": 67
+  "success": true,
+  "data": {
+    "problemId": 3,
+    "answerType": "OBJECTIVE",
+    "answerStatus": "PARTIAL",
+    "explanation": "정답은 1번과 2번입니다.",
+    "problemAnswers": ["1", "2"],
+    "userAnswers": ["1", "3"],
+    "answerCorrectRate": 67
+  },
+  "error": null
+}
+```
+
+공통 오류 응답 예시:
+
+```json
+{
+  "success": false,
+  "data": null,
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "chapterId: must not be null"
+  }
 }
 ```
 

--- a/quiz-api/src/main/java/com/project/quiz/api/common/CommonErrorResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/CommonErrorResponse.java
@@ -1,0 +1,16 @@
+package com.project.quiz.api.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommonErrorResponse", description = "오류 공통 응답")
+public record CommonErrorResponse(
+        @Schema(description = "요청 성공 여부", example = "false")
+        boolean success,
+
+        @Schema(description = "성공 응답 데이터", nullable = true, example = "null")
+        Object data,
+
+        @Schema(description = "오류 정보")
+        ErrorResponse error
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/common/CommonResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/CommonResponse.java
@@ -1,0 +1,23 @@
+package com.project.quiz.api.common;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "API 공통 응답")
+public record CommonResponse<T>(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 응답 데이터", nullable = true)
+        T data,
+
+        @Schema(description = "오류 정보", nullable = true)
+        ErrorResponse error
+) {
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>(true, data, null);
+    }
+
+    public static <T> CommonResponse<T> failure(String code, String message) {
+        return new CommonResponse<>(false, null, new ErrorResponse(code, message));
+    }
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -19,49 +19,55 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ChapterNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleChapterNotFound(ChapterNotFoundException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleChapterNotFound(ChapterNotFoundException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("CHAPTER_NOT_FOUND", exception.getMessage()));
+                .body(CommonResponse.failure("CHAPTER_NOT_FOUND", exception.getMessage()));
     }
 
     @ExceptionHandler(NoAvailableProblemException.class)
-    public ResponseEntity<ErrorResponse> handleNoAvailableProblem(NoAvailableProblemException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleNoAvailableProblem(NoAvailableProblemException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(new ErrorResponse("NO_AVAILABLE_PROBLEM", exception.getMessage()));
+                .body(CommonResponse.failure("NO_AVAILABLE_PROBLEM", exception.getMessage()));
     }
 
     @ExceptionHandler(ProblemNotFoundInChapterException.class)
-    public ResponseEntity<ErrorResponse> handleProblemNotFoundInChapter(ProblemNotFoundInChapterException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleProblemNotFoundInChapter(ProblemNotFoundInChapterException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("PROBLEM_NOT_FOUND_IN_CHAPTER", exception.getMessage()));
+                .body(CommonResponse.failure("PROBLEM_NOT_FOUND_IN_CHAPTER", exception.getMessage()));
     }
 
     @ExceptionHandler(SolvedProblemNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleSolvedProblemNotFound(SolvedProblemNotFoundException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleSolvedProblemNotFound(SolvedProblemNotFoundException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ErrorResponse("SOLVED_PROBLEM_NOT_FOUND", exception.getMessage()));
+                .body(CommonResponse.failure("SOLVED_PROBLEM_NOT_FOUND", exception.getMessage()));
     }
 
     @ExceptionHandler(ProblemAnswerTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleProblemAnswerTypeMismatch(ProblemAnswerTypeMismatchException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleProblemAnswerTypeMismatch(ProblemAnswerTypeMismatchException exception) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(new ErrorResponse("PROBLEM_ANSWER_TYPE_MISMATCH", exception.getMessage()));
+                .body(CommonResponse.failure("PROBLEM_ANSWER_TYPE_MISMATCH", exception.getMessage()));
     }
 
     @ExceptionHandler(InvalidProblemChoiceException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidProblemChoice(InvalidProblemChoiceException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleInvalidProblemChoice(InvalidProblemChoiceException exception) {
         return ResponseEntity.badRequest()
-                .body(new ErrorResponse("INVALID_PROBLEM_CHOICE", exception.getMessage()));
+                .body(CommonResponse.failure("INVALID_PROBLEM_CHOICE", exception.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException exception) {
+    public ResponseEntity<CommonResponse<Void>> handleValidation(MethodArgumentNotValidException exception) {
         String message = exception.getBindingResult().getFieldErrors().stream()
                 .map(this::formatFieldError)
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest()
-                .body(new ErrorResponse("INVALID_REQUEST", message));
+                .body(CommonResponse.failure("INVALID_REQUEST", message));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<CommonResponse<Void>> handleRuntimeException(RuntimeException exception) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponse.failure("INTERNAL_SERVER_ERROR", "Unexpected server error"));
     }
 
     private String formatFieldError(FieldError fieldError) {

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemCommonResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetRandomProblemCommonResponse.java
@@ -1,0 +1,17 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetRandomProblemCommonResponse", description = "랜덤 문제 조회 공통 응답")
+public record GetRandomProblemCommonResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 응답 데이터", nullable = true)
+        GetRandomProblemResponse data,
+
+        @Schema(description = "오류 정보", nullable = true)
+        ErrorResponse error
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailCommonResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/GetSolvedProblemDetailCommonResponse.java
@@ -1,0 +1,17 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetSolvedProblemDetailCommonResponse", description = "풀었던 문제 상세 조회 공통 응답")
+public record GetSolvedProblemDetailCommonResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 응답 데이터", nullable = true)
+        GetSolvedProblemDetailResponse data,
+
+        @Schema(description = "오류 정보", nullable = true)
+        ErrorResponse error
+) {
+}

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
@@ -1,6 +1,7 @@
 package com.project.quiz.api.problem;
 
-import com.project.quiz.api.common.ErrorResponse;
+import com.project.quiz.api.common.CommonErrorResponse;
+import com.project.quiz.api.common.CommonResponse;
 import com.project.quiz.application.solving.model.GetRandomProblemCommand;
 import com.project.quiz.application.solving.model.GetRandomProblemResult;
 import com.project.quiz.application.solving.model.GetSolvedProblemDetailCommand;
@@ -42,29 +43,33 @@ public class ProblemController {
             description = "선택한 단원에서 이미 푼 문제와 직전에 건너뛴 문제를 제외하고 랜덤 문제 1개를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "랜덤 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "랜덤 문제가 정상적으로 반환되었습니다.",
+                    content = @Content(schema = @Schema(implementation = GetRandomProblemCommonResponse.class))
+            ),
             @ApiResponse(
                     responseCode = "400",
                     description = "잘못된 요청입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",
                     description = "해당 단원을 찾을 수 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "409",
                     description = "해당 단원에 더 이상 출제 가능한 문제가 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
     @PostMapping("/random")
-    public ResponseEntity<GetRandomProblemResponse> getRandomProblem(@Valid @RequestBody GetRandomProblemRequest request) {
+    public ResponseEntity<CommonResponse<GetRandomProblemResponse>> getRandomProblem(@Valid @RequestBody GetRandomProblemRequest request) {
         GetRandomProblemResult result = getRandomProblemService.getRandomProblem(
                 new GetRandomProblemCommand(request.userId(), request.chapterId())
         );
-        return ResponseEntity.ok(toRandomProblemResponse(result));
+        return ResponseEntity.ok(CommonResponse.success(toRandomProblemResponse(result)));
     }
 
     @Operation(
@@ -72,52 +77,60 @@ public class ProblemController {
             description = "현재 문제를 건너뛴 뒤 같은 단원에서 다음 랜덤 문제 1개를 반환합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "문제를 건너뛰고 다음 문제가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "문제를 건너뛰고 다음 문제가 정상적으로 반환되었습니다.",
+                    content = @Content(schema = @Schema(implementation = GetRandomProblemCommonResponse.class))
+            ),
             @ApiResponse(
                     responseCode = "400",
                     description = "잘못된 요청입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",
                     description = "해당 단원 또는 문제가 존재하지 않습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "409",
                     description = "건너뛴 이후 더 이상 출제 가능한 문제가 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
     @PostMapping("/skip")
-    public ResponseEntity<GetRandomProblemResponse> skipProblem(@Valid @RequestBody SkipProblemRequest request) {
+    public ResponseEntity<CommonResponse<GetRandomProblemResponse>> skipProblem(@Valid @RequestBody SkipProblemRequest request) {
         GetRandomProblemResult result = skipProblemService.skipProblem(
                 new SkipProblemCommand(request.userId(), request.chapterId(), request.problemId())
         );
-        return ResponseEntity.ok(toRandomProblemResponse(result));
+        return ResponseEntity.ok(CommonResponse.success(toRandomProblemResponse(result)));
     }
 
     @Operation(summary = "풀었던 문제 상세 조회", description = "사용자가 이전에 풀었던 문제의 채점 결과, 해설, 정답, 제출 답안을 상세 조회합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "풀었던 문제 상세가 정상적으로 반환되었습니다."),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "풀었던 문제 상세가 정상적으로 반환되었습니다.",
+                    content = @Content(schema = @Schema(implementation = GetSolvedProblemDetailCommonResponse.class))
+            ),
             @ApiResponse(
                     responseCode = "400",
                     description = "잘못된 요청입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",
                     description = "문제 또는 풀이 이력을 찾을 수 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
     @PostMapping("/detail")
-    public ResponseEntity<GetSolvedProblemDetailResponse> getSolvedProblemDetail(@Valid @RequestBody GetSolvedProblemDetailRequest request) {
+    public ResponseEntity<CommonResponse<GetSolvedProblemDetailResponse>> getSolvedProblemDetail(@Valid @RequestBody GetSolvedProblemDetailRequest request) {
         GetSolvedProblemDetailResult result = getSolvedProblemDetailService.getDetail(
                 new GetSolvedProblemDetailCommand(request.userId(), request.problemId())
         );
 
-        return ResponseEntity.ok(new GetSolvedProblemDetailResponse(
+        return ResponseEntity.ok(CommonResponse.success(new GetSolvedProblemDetailResponse(
                 result.problemId(),
                 result.answerType(),
                 result.answerStatus(),
@@ -125,30 +138,34 @@ public class ProblemController {
                 result.problemAnswers(),
                 result.userAnswers(),
                 result.answerCorrectRate()
-        ));
+        )));
     }
 
     @Operation(summary = "문제 제출", description = "객관식 또는 주관식 답안을 제출하고 즉시 채점 결과와 해설을 반환합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "문제 제출이 정상적으로 처리되었습니다."),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "문제 제출이 정상적으로 처리되었습니다.",
+                    content = @Content(schema = @Schema(implementation = SubmitProblemAnswerCommonResponse.class))
+            ),
             @ApiResponse(
                     responseCode = "400",
                     description = "잘못된 요청입니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "404",
                     description = "문제를 찾을 수 없습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             ),
             @ApiResponse(
                     responseCode = "409",
                     description = "문제의 답안 형식과 제출 형식이 일치하지 않습니다.",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
     @PostMapping("/submit")
-    public ResponseEntity<SubmitProblemAnswerResponse> submit(@Valid @RequestBody SubmitProblemAnswerRequest request) {
+    public ResponseEntity<CommonResponse<SubmitProblemAnswerResponse>> submit(@Valid @RequestBody SubmitProblemAnswerRequest request) {
         SubmitProblemAnswerResult result = submitProblemAnswerService.submit(
                 new SubmitProblemAnswerCommand(
                         request.problemId(),
@@ -159,13 +176,13 @@ public class ProblemController {
                 )
         );
 
-        return ResponseEntity.ok(new SubmitProblemAnswerResponse(
+        return ResponseEntity.ok(CommonResponse.success(new SubmitProblemAnswerResponse(
                 result.problemId(),
                 result.answerType(),
                 result.answerStatus(),
                 result.explanation(),
                 result.problemAnswers()
-        ));
+        )));
     }
 
     private GetRandomProblemResponse toRandomProblemResponse(GetRandomProblemResult result) {

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerCommonResponse.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/SubmitProblemAnswerCommonResponse.java
@@ -1,0 +1,17 @@
+package com.project.quiz.api.problem;
+
+import com.project.quiz.api.common.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "SubmitProblemAnswerCommonResponse", description = "문제 제출 공통 응답")
+public record SubmitProblemAnswerCommonResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+
+        @Schema(description = "성공 응답 데이터", nullable = true)
+        SubmitProblemAnswerResponse data,
+
+        @Schema(description = "오류 정보", nullable = true)
+        ErrorResponse error
+) {
+}

--- a/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
@@ -82,10 +82,12 @@ class ProblemControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(1))
-                .andExpect(jsonPath("$.content").value("문제 설명"))
-                .andExpect(jsonPath("$.choices[0]").value("보기 1"))
-                .andExpect(jsonPath("$.answerCorrectRate").value(67));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(1))
+                .andExpect(jsonPath("$.data.content").value("문제 설명"))
+                .andExpect(jsonPath("$.data.choices[0]").value("보기 1"))
+                .andExpect(jsonPath("$.data.answerCorrectRate").value(67))
+                .andExpect(jsonPath("$.error").isEmpty());
 
         verify(getRandomProblemService).getRandomProblem(any());
     }
@@ -94,10 +96,12 @@ class ProblemControllerTest {
     @DisplayName("랜덤 문제 요청 검증 실패면 400을 반환한다")
     void returnBadRequestWhenRandomRequestInvalid() throws Exception {
         mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(null, 1L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(null, 1L))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
     }
 
     @Test
@@ -107,10 +111,11 @@ class ProblemControllerTest {
                 .thenThrow(new ChapterNotFoundException(999L));
 
         mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 999L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 999L))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("CHAPTER_NOT_FOUND"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("CHAPTER_NOT_FOUND"));
     }
 
     @Test
@@ -120,10 +125,11 @@ class ProblemControllerTest {
                 .thenThrow(new NoAvailableProblemException(1L, 1L));
 
         mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("NO_AVAILABLE_PROBLEM"));
     }
 
     @Test
@@ -141,21 +147,24 @@ class ProblemControllerTest {
                 ));
 
         mockMvc.perform(post("/api/problems/skip")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(101))
-                .andExpect(jsonPath("$.content").value("다음 문제"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(101))
+                .andExpect(jsonPath("$.data.content").value("다음 문제"))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
     @DisplayName("문제 넘기기에서 잘못된 요청이면 400을 반환한다")
     void returnBadRequestWhenSkipRequestInvalid() throws Exception {
         mockMvc.perform(post("/api/problems/skip")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, null, 100L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, null, 100L))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
     }
 
     @Test
@@ -165,10 +174,11 @@ class ProblemControllerTest {
                 .thenThrow(new ProblemNotFoundInChapterException(1L, 100L));
 
         mockMvc.perform(post("/api/problems/skip")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SkipProblemRequest(1L, 1L, 100L))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
     }
 
     @Test
@@ -186,24 +196,27 @@ class ProblemControllerTest {
                 ));
 
         mockMvc.perform(post("/api/problems/detail")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(3))
-                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
-                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
-                .andExpect(jsonPath("$.userAnswers[1]").value("3"))
-                .andExpect(jsonPath("$.answerCorrectRate").value(67));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(3))
+                .andExpect(jsonPath("$.data.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.data.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.data.userAnswers[1]").value("3"))
+                .andExpect(jsonPath("$.data.answerCorrectRate").value(67))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
     @DisplayName("풀었던 문제 상세 요청이 잘못되면 400을 반환한다")
     void returnBadRequestWhenDetailRequestInvalid() throws Exception {
         mockMvc.perform(post("/api/problems/detail")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, null))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
     }
 
     @Test
@@ -213,10 +226,11 @@ class ProblemControllerTest {
                 .thenThrow(new SolvedProblemNotFoundException(1L, 3L));
 
         mockMvc.perform(post("/api/problems/detail")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("SOLVED_PROBLEM_NOT_FOUND"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("SOLVED_PROBLEM_NOT_FOUND"));
     }
 
     @Test
@@ -226,12 +240,14 @@ class ProblemControllerTest {
                 .thenReturn(new SubmitProblemAnswerResult(1001L, ProblemAnswerFormat.OBJECTIVE, AnswerStatus.PARTIAL, "해설", List.of("1", "2")));
 
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 3), null))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(1001))
-                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
-                .andExpect(jsonPath("$.problemAnswers[0]").value("1"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(1001))
+                .andExpect(jsonPath("$.data.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.data.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -241,10 +257,11 @@ class ProblemControllerTest {
                 .thenThrow(new ProblemNotFoundInChapterException(null, 999L));
 
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(999L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(999L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PROBLEM_NOT_FOUND_IN_CHAPTER"));
     }
 
     @Test
@@ -254,65 +271,71 @@ class ProblemControllerTest {
                 .thenThrow(new ProblemAnswerTypeMismatchException(1001L));
 
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), null))))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.code").value("PROBLEM_ANSWER_TYPE_MISMATCH"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("PROBLEM_ANSWER_TYPE_MISMATCH"));
     }
 
     @Test
     @DisplayName("객관식 제출에서 선택지가 비어 있으면 400을 반환한다")
     void returnBadRequestWhenObjectiveChoicesMissing() throws Exception {
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(), null))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
-                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must not be empty for OBJECTIVE answerType"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("selectedChoices: selectedChoices must not be empty for OBJECTIVE answerType"));
     }
 
     @Test
     @DisplayName("주관식 제출에서 답안이 비어 있으면 400을 반환한다")
     void returnBadRequestWhenSubjectiveAnswerMissing() throws Exception {
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, null, "   "))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, null, "   "))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
-                .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must not be blank for SUBJECTIVE answerType"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("subjectiveAnswer: subjectiveAnswer must not be blank for SUBJECTIVE answerType"));
     }
 
     @Test
     @DisplayName("객관식 제출에서 주관식 답안이 같이 오면 400을 반환한다")
     void returnBadRequestWhenObjectiveContainsSubjectiveAnswer() throws Exception {
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), "text"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1), "text"))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
-                .andExpect(jsonPath("$.message").value("subjectiveAnswer: subjectiveAnswer must be blank for OBJECTIVE answerType"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("subjectiveAnswer: subjectiveAnswer must be blank for OBJECTIVE answerType"));
     }
 
     @Test
     @DisplayName("주관식 제출에서 객관식 선택지가 같이 오면 400을 반환한다")
     void returnBadRequestWhenSubjectiveContainsSelectedChoices() throws Exception {
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, List.of(1), "answer"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.SUBJECTIVE, List.of(1), "answer"))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
-                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must be empty for SUBJECTIVE answerType"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("selectedChoices: selectedChoices must be empty for SUBJECTIVE answerType"));
     }
 
     @Test
     @DisplayName("객관식 제출에서 중복 선택지가 오면 400을 반환한다")
     void returnBadRequestWhenObjectiveContainsDuplicateChoices() throws Exception {
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 1), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(1, 1), null))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
-                .andExpect(jsonPath("$.message").value("selectedChoices: selectedChoices must not contain duplicates"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.message").value("selectedChoices: selectedChoices must not contain duplicates"));
     }
 
     @Test
@@ -322,9 +345,25 @@ class ProblemControllerTest {
                 .thenThrow(new InvalidProblemChoiceException(1001L, List.of(7)));
 
         mockMvc.perform(post("/api/problems/submit")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(7), null))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new SubmitProblemAnswerRequest(1001L, 1L, ProblemAnswerFormat.OBJECTIVE, List.of(7), null))))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("INVALID_PROBLEM_CHOICE"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_PROBLEM_CHOICE"));
     }
+
+    @Test
+    @DisplayName("예상하지 못한 런타임 예외가 발생하면 500 공통 응답을 반환한다")
+    void returnInternalServerErrorWhenUnexpectedRuntimeExceptionOccurs() throws Exception {
+        when(getRandomProblemService.getRandomProblem(any()))
+                .thenThrow(new RuntimeException("boom"));
+
+        mockMvc.perform(post("/api/problems/random")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.error.message").value("Unexpected server error"));
+}
 }

--- a/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
+++ b/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
@@ -141,11 +141,13 @@ class GetRandomProblemEndToEndTest {
                                 "userId", 1L
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(102))
-                .andExpect(jsonPath("$.content").value("출제될 문제"))
-                .andExpect(jsonPath("$.choices[0]").value("102-1"))
-                .andExpect(jsonPath("$.choices[4]").value("102-5"))
-                .andExpect(jsonPath("$.answerCorrectRate").value(nullValue()));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(102))
+                .andExpect(jsonPath("$.data.content").value("출제될 문제"))
+                .andExpect(jsonPath("$.data.choices[0]").value("102-1"))
+                .andExpect(jsonPath("$.data.choices[4]").value("102-5"))
+                .andExpect(jsonPath("$.data.answerCorrectRate").value(nullValue()))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -176,7 +178,8 @@ class GetRandomProblemEndToEndTest {
                                 "userId", 1L
                         ))))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.code").value("NO_AVAILABLE_PROBLEM"));
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("NO_AVAILABLE_PROBLEM"));
     }
 
     @Test
@@ -208,8 +211,10 @@ class GetRandomProblemEndToEndTest {
                                 "problemId", 1001L
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(1002))
-                .andExpect(jsonPath("$.content").value("다음 문제"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(1002))
+                .andExpect(jsonPath("$.data.content").value("다음 문제"))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -243,11 +248,13 @@ class GetRandomProblemEndToEndTest {
                                 "selectedChoices", List.of(1, 3)
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(3001))
-                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
-                .andExpect(jsonPath("$.explanation").value("정답은 1번과 2번입니다."))
-                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
-                .andExpect(jsonPath("$.problemAnswers[1]").value("2"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(3001))
+                .andExpect(jsonPath("$.data.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.data.explanation").value("정답은 1번과 2번입니다."))
+                .andExpect(jsonPath("$.data.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.data.problemAnswers[1]").value("2"))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -293,13 +300,15 @@ class GetRandomProblemEndToEndTest {
                                 "problemId", 4001L
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.problemId").value(4001))
-                .andExpect(jsonPath("$.answerStatus").value("PARTIAL"))
-                .andExpect(jsonPath("$.problemAnswers[0]").value("1"))
-                .andExpect(jsonPath("$.problemAnswers[1]").value("2"))
-                .andExpect(jsonPath("$.userAnswers[0]").value("1"))
-                .andExpect(jsonPath("$.userAnswers[1]").value("3"))
-                .andExpect(jsonPath("$.answerCorrectRate").value(nullValue()));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.problemId").value(4001))
+                .andExpect(jsonPath("$.data.answerStatus").value("PARTIAL"))
+                .andExpect(jsonPath("$.data.problemAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.data.problemAnswers[1]").value("2"))
+                .andExpect(jsonPath("$.data.userAnswers[0]").value("1"))
+                .andExpect(jsonPath("$.data.userAnswers[1]").value("3"))
+                .andExpect(jsonPath("$.data.answerCorrectRate").value(nullValue()))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -332,7 +341,9 @@ class GetRandomProblemEndToEndTest {
                                 "selectedChoices", List.of(2)
                         ))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.answerStatus").value("CORRECT"));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.answerStatus").value("CORRECT"))
+                .andExpect(jsonPath("$.error").isEmpty());
 
         ProblemStatisticsJpaEntity statistics = problemStatisticsJpaRepository.findById(5001L).orElseThrow();
 


### PR DESCRIPTION
## 요약

  `CommonResponse`를 도입해 문제 풀이 API의 성공/실패 응답 계약을 통일했습니다.
  기존의 HTTP status 정책은 유지하면서, 응답 본문을 `success`, `data`, `error` 구조로 맞췄습니다.

  ## 주요 변경

  - `CommonResponse<T>` 추가
  - 예외 응답을 공통 응답 형식으로 변경
  - `ProblemController` 성공 응답을 공통 응답으로 래핑
  - Swagger 응답 schema 갱신
  - API 문서 예시 갱신
  - 컨트롤러 테스트 및 E2E 테스트 JSON path 수정

  ## 응답 예시

  성공:
  ```json
  {
    "success": true,
    "data": {
      "problemId": 1001
    },
    "error": null
  }

  실패:

  {
    "success": false,
    "data": null,
    "error": {
      "code": "INVALID_REQUEST",
      "message": "chapterId: must not be null"
    }
  }

  ## 검증

  - ./gradlew :quiz-api:test
  - ./gradlew test
