### PR TITLE
docs: Codex skill 문서 구조 정비

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -1,0 +1,47 @@
+# Skills Guide
+
+이 디렉터리의 skill은 Codex가 백엔드 과제/프로젝트를 반복 가능한 방식으로 수행하도록 돕는 작업 단위 가이드입니다.
+
+핵심 원칙:
+
+- 각 skill은 **언제 쓰는지** (`Use When`)가 명확해야 합니다.
+- 각 skill은 **무엇을 남기면 끝나는지** (`Deliverables`, `Exit Criteria`)가 명확해야 합니다.
+- 각 skill은 **무엇을 하지 않는지** (`Non-Goals`)가 명확해야 합니다.
+- 각 skill은 다음 단계에 무엇을 넘기는지 (`Handoff`)가 명확해야 합니다.
+
+## Recommended Sequence
+
+일반적인 과제/기능 구현 흐름은 아래 순서를 기본값으로 둡니다.
+
+1. `task-read-and-plan`
+   - 요구사항, 숨은 제약, 핵심 리스크를 정리
+2. `spring-architecture`
+   - 상위 구조와 boundary를 고정
+3. `domain-modeling`
+   - domain concept와 책임 위치를 결정
+4. `query-and-performance`
+   - read path와 성능 리스크를 먼저 정리
+5. `persistence-and-indexing`
+   - schema, repository, index 방향 결정
+6. `api-delivery`
+   - request/response DTO와 endpoint 구현
+7. `test-and-verify`
+   - 핵심 시나리오와 회귀 리스크 검증
+8. `submission-readme-and-review`
+   - reviewer-facing 설명과 제출 품질 정리
+9. `assignment-guardrails`
+   - 전 과정에서 상시 적용하는 제약 조건
+
+## How To Use
+
+- 설계가 먼저 필요한 문제면 `task-read-and-plan`부터 시작합니다.
+- skill은 가능한 한 한 번에 하나의 핵심 결정을 끝내는 데 집중합니다.
+- 한 skill이 끝나면 `Handoff`에 따라 다음 skill로 넘깁니다.
+- skill이 요구하지 않는 영역은 `Non-Goals`에 따라 억지로 건드리지 않습니다.
+
+## Success Criteria For The Skill Set
+
+- implementer가 다음 단계에서 다시 큰 결정을 하지 않아도 된다
+- skill 간 경계가 겹치지 않는다
+- 과제마다 같은 품질 기준을 반복 적용할 수 있다
+- AI가 너무 일찍 멈추거나 불필요하게 과하게 작업하지 않는다

--- a/.codex/skills/api-delivery/SKILL.md
+++ b/.codex/skills/api-delivery/SKILL.md
@@ -9,12 +9,25 @@ description: Use when implementing APIs for problem solving and solve history wi
 
 Implement APIs with clear boundaries and maintainable structure.
 
-## Target APIs
+## Use When
 
-- Get chapter questions
-- Submit solve answers
-- Get solve history list
-- Get solve history detail
+- adding or refactoring public endpoints
+- defining request/response DTOs
+- connecting controller -> application -> domain flow
+
+## Inputs
+
+- requirement brief
+- domain-modeling output
+- existing API conventions and error policy
+
+## Deliverables
+
+- endpoint list with method and path
+- request/response DTOs
+- controller methods wired to application layer
+- exception-to-HTTP mapping for major failure cases
+- at least minimal controller test coverage for success and failure flows
 
 ## Instructions
 
@@ -32,6 +45,12 @@ Implement APIs with clear boundaries and maintainable structure.
 - Separate list vs detail responses
 - Explicit DTO fields only
 
+## Non-Goals
+
+- moving business rules into controllers
+- designing storage/index strategy in detail
+- using API implementation to compensate for unresolved domain decisions
+
 ## Error Handling
 
 Cover:
@@ -41,8 +60,16 @@ Cover:
 - duplicate or invalid submission
 - unauthorized access
 
-## Done Criteria
+## Exit Criteria
 
-- APIs are complete and callable
-- Layer separation is maintained
-- DTOs are stable and explicit
+- each endpoint has a fixed request/response shape
+- controllers do not contain domain or persistence logic
+- entities are not exposed directly to API consumers
+- at least one success case and one failure case per endpoint can be verified by tests
+- the implementer does not need to make additional API contract decisions
+
+## Handoff
+
+- `test-and-verify` can extend controller/service tests from a stable contract
+- `submission-readme-and-review` can document the API without guessing response shapes
+- `spring-architecture` can validate that boundaries remain thin and explainable

--- a/.codex/skills/assignment-guardrails/SKILL.md
+++ b/.codex/skills/assignment-guardrails/SKILL.md
@@ -30,6 +30,12 @@ Prevent overengineering and keep the solution aligned with assignment expectatio
 - readable code > abstract code
 - practical solution > “perfect” architecture
 
+## Non-Goals
+
+- blocking justified abstractions that clearly improve the solution
+- treating all optimization or structure as overengineering
+- replacing the need for explicit architecture or domain decisions
+
 ## Done Criteria
 
 - solution is understandable within minutes

--- a/.codex/skills/domain-modeling/SKILL.md
+++ b/.codex/skills/domain-modeling/SKILL.md
@@ -9,13 +9,25 @@ description: Use when designing domain entities and responsibilities for solving
 
 Model the domain so behavior is expressed clearly, not just data structure.
 
-## Core Concepts
+## Use When
 
-- Chapter
-- Question
-- SolveAttempt (or SolveHistory)
-- SolveAnswer
-- SolveResult / Score
+- interpreting assignment requirements into domain language
+- deciding where grading, solving state, and statistics rules should live
+- preventing application services from becoming rule-heavy coordinators
+
+## Inputs
+
+- requirement brief
+- existing code structure if present
+- core business rules and edge cases
+- target API/use case expectations
+
+## Deliverables
+
+- core domain concepts with 1-line responsibility each
+- entity / value object / domain service split
+- grading, solving, and statistics responsibility placement
+- aggregate root candidates and why they are roots
 
 ## Instructions
 
@@ -31,14 +43,27 @@ Model the domain so behavior is expressed clearly, not just data structure.
 - Prefer single-direction relationships
 - Use value objects when they improve clarity
 
+## Non-Goals
+
+- deciding persistence table structure in detail
+- designing controller/request/response DTOs
+- forcing DDD patterns where simple entities are sufficient
+
 ## Design Guidance
 
 - Question → validates correctness
 - SolveAttempt → aggregates answers and calculates result
 - Domain services → only when logic doesn’t belong to a single entity
 
-## Done Criteria
+## Exit Criteria
 
-- Entities have clear responsibilities
-- Business rules are not centralized in one service
-- Model supports both solving and history querying
+- core concepts are reduced to a stable set rather than a long noun list
+- each major business rule has an explicit home in entity, value object, or domain service
+- the implementer does not need to decide where grading or solving rules belong
+- the model supports both solve flow and solve history use cases
+
+## Handoff
+
+- `api-delivery` can define commands/results and DTOs using the chosen domain language
+- `persistence-and-indexing` can map storage based on decided aggregates and relationships
+- `submission-readme-and-review` can explain why responsibilities were placed this way

--- a/.codex/skills/persistence-and-indexing/SKILL.md
+++ b/.codex/skills/persistence-and-indexing/SKILL.md
@@ -9,6 +9,27 @@ description: Use when designing database schema and repository access patterns a
 
 Design database structure and access patterns for both correctness and performance.
 
+## Use When
+
+- defining schema from use cases rather than from entities alone
+- deciding repository methods and storage boundaries
+- choosing indexes based on concrete access patterns
+
+## Inputs
+
+- domain-modeling output
+- query-and-performance output
+- requirement brief
+- current schema or seed data if present
+
+## Deliverables
+
+- table structure aligned to core use cases
+- repository method candidates tied to actual queries
+- key relationships and ownership decisions
+- major index candidates with rationale
+- notes on tradeoffs or intentionally deferred optimizations
+
 ## Instructions
 
 - Define table structure for:
@@ -35,12 +56,25 @@ Consider indexes on:
 - Avoid generic findAll usage
 - Prefer targeted query methods
 
+## Non-Goals
+
+- deciding business rule ownership in the domain model
+- defining public API request/response contracts
+- optimizing every table/index before concrete query needs exist
+
 ## Practical Tip
 
 Even if DB is small, document index decisions in README.
 
-## Done Criteria
+## Exit Criteria
 
-- Schema supports use cases
-- Repository methods match queries
-- Index decisions are explainable
+- schema choices can be explained from write/read use cases, not only from object structure
+- repository methods map directly to concrete query needs
+- key indexes are documented with query-based reasoning
+- the implementer does not need to decide table shape or first-order index direction during coding
+
+## Handoff
+
+- `query-and-performance` can validate that repositories support the intended read paths
+- `submission-readme-and-review` can document schema and index rationale
+- implementation can proceed without reopening storage design questions

--- a/.codex/skills/query-and-performance/SKILL.md
+++ b/.codex/skills/query-and-performance/SKILL.md
@@ -9,11 +9,26 @@ description: Use when implementing or reviewing read APIs to ensure efficient qu
 
 Ensure read operations scale and avoid common ORM pitfalls.
 
-## Focus Areas
+## Use When
 
-- Solve history list
-- Solve history detail
-- Chapter question retrieval
+- designing or reviewing read APIs
+- splitting list vs detail query responsibilities
+- checking index needs for real access patterns
+
+## Inputs
+
+- use case list for each read path
+- payload requirements for list and detail responses
+- current repository/query structure
+- expected sorting, pagination, and filtering behavior
+
+## Deliverables
+
+- read-path query strategy per use case
+- list/detail split decision
+- repository or projection method candidates
+- major index candidates tied to concrete queries
+- note of known performance risks or intentional tradeoffs
 
 ## Instructions
 
@@ -41,9 +56,22 @@ Detail:
 - Do not mix list and detail responsibilities
 - Always define sorting (latest-first)
 
-## Done Criteria
+## Non-Goals
 
-- List queries are lightweight
-- Detail queries are separated
-- Pagination is applied
-- N+1 risk is addressed
+- redesigning the entire domain model
+- inventing indexes without tying them to concrete access patterns
+- adding pagination to flows where the assignment does not need it
+
+## Exit Criteria
+
+- each read use case has an explicit query approach
+- list and detail are separated where payload shape differs materially
+- pagination and sorting rules are fixed, not implied
+- major N+1 risks and heavy fetch paths are either removed or explicitly accepted
+- the implementer does not need to decide query shape or index direction during coding
+
+## Handoff
+
+- `persistence-and-indexing` can design schema/indexes from concrete access patterns
+- `test-and-verify` can validate ordering, pagination, and query behavior
+- `submission-readme-and-review` can explain performance considerations with evidence

--- a/.codex/skills/spring-architecture/SKILL.md
+++ b/.codex/skills/spring-architecture/SKILL.md
@@ -11,6 +11,20 @@ Use this skill when the assignment evaluates more than endpoint completion and e
 
 Guide implementation toward a reviewer-friendly Spring Boot structure on Java 21.
 
+## Inputs
+
+- requirement brief or plan
+- target Java/Spring version assumptions
+- existing module/package structure if present
+- expected deliverables such as Swagger, README, and Docker Compose
+
+## Deliverables
+
+- architecture direction for module/package boundaries
+- explicit boundary rules between API, application, domain, and infrastructure
+- key performance considerations for answer-rate and read paths
+- delivery checklist covering docs and local startup readiness
+
 This skill is the architectural counterpart to the existing project skills:
 
 - `task-read-and-plan` for requirement extraction
@@ -29,6 +43,18 @@ This skill is the architectural counterpart to the existing project skills:
 - making solve submission and history lookup flows testable
 - checking answer-rate calculation and query performance
 - ensuring Swagger, `README.md`, and Docker Compose are part of the deliverable
+
+## Orchestration Role
+
+- use this skill to set architectural direction before implementation details sprawl
+- it should not replace `domain-modeling`, `api-delivery`, or `persistence-and-indexing`
+- it should constrain those skills so they make compatible decisions
+
+## Non-Goals
+
+- implementing concrete APIs, repositories, or tests by itself
+- replacing detailed domain or persistence design work
+- justifying multi-module by default when package boundaries are sufficient
 
 ## Architecture Rules
 
@@ -51,10 +77,15 @@ This skill is the architectural counterpart to the existing project skills:
 - `README.md` must explain architecture, run steps, tests, and tradeoffs.
 - `docker-compose.yml` should start the application and DB with explicit environment settings.
 
-## Final Check
+## Exit Criteria
 
-- Java version assumptions match Java 21.
-- architecture is explainable in a few sentences
-- domain language is reflected in code structure
-- performance-sensitive reads are not accidentally expensive
-- docs and local startup are reviewer-ready
+- Java version and framework assumptions are explicit and consistent
+- architecture can be explained briefly without hand-waving
+- module/package boundaries are stable enough that implementation skills do not need to redefine them
+- answer-rate and read-path risks have architectural owners, not just code-level fixes
+- docs and local startup expectations are clear enough for final delivery
+
+## Handoff
+
+- `domain-modeling`, `api-delivery`, and `persistence-and-indexing` can proceed within stable boundaries
+- `submission-readme-and-review` can reuse the architectural rationale directly

--- a/.codex/skills/submission-readme-and-review/SKILL.md
+++ b/.codex/skills/submission-readme-and-review/SKILL.md
@@ -9,6 +9,27 @@ description: Use when preparing final assignment submission to clearly explain d
 
 Make the solution easy to evaluate and understand.
 
+## Use When
+
+- preparing the final assignment or take-home submission
+- README must explain not just features but design reasoning
+- an evaluator needs to quickly understand tradeoffs and quality signals
+
+## Inputs
+
+- final or near-final implementation
+- architecture and domain decisions
+- performance and index considerations
+- test coverage and local run steps
+
+## Deliverables
+
+- concise reviewer-facing README or equivalent docs
+- architecture/design explanation in Korean
+- performance and index rationale
+- test coverage summary
+- run instructions and assumptions
+
 ## Include
 
 1. Assignment summary
@@ -36,10 +57,17 @@ Make the solution easy to evaluate and understand.
 - error handling present
 - tests included
 
-## Done Criteria
+## Exit Criteria
 
-- README is concise but clear
-- evaluator can understand quickly
+- a technical reviewer can understand the architecture and tradeoffs in a few minutes
+- run steps, tests, and key design decisions are all present
+- README tone is natural Korean and does not read like translated boilerplate
+- the implementer does not need to decide what is important enough to document
+
+## Handoff
+
+- final submission is reviewer-ready
+- interview or review discussion can reuse the documented decisions directly
 
 ## Rules
 
@@ -47,6 +75,12 @@ Make the solution easy to evaluate and understand.
 - Use clear and natural Korean (avoid awkward translation tone)
 - Keep technical terms (API, DTO, index, pagination) in English if needed
 - Do not mix Korean and English inconsistently
+
+## Non-Goals
+
+- turning README into a full design novel
+- documenting every internal class or low-level detail
+- hiding tradeoffs to make the solution look artificially perfect
 
 ## Writing Style
 

--- a/.codex/skills/task-read-and-plan/SKILL.md
+++ b/.codex/skills/task-read-and-plan/SKILL.md
@@ -9,6 +9,28 @@ description: Use when starting a backend assignment to extract requirements, hid
 
 Turn a short assignment brief into a structured implementation plan before writing code.
 
+## Use When
+
+- starting a new assignment or feature from a brief
+- requirements are short but imply hidden domain or performance concerns
+- the next step should be planning rather than coding
+
+## Inputs
+
+- assignment brief or ticket
+- existing repo context if available
+- explicit constraints such as stack, deadlines, and deliverables
+
+## Deliverables
+
+- functional requirements list
+- hidden constraints and assumptions
+- core domain concepts
+- API candidates
+- persistence outline
+- performance risks
+- test plan
+
 ## Instructions
 
 1. Extract functional requirements
@@ -26,6 +48,12 @@ Turn a short assignment brief into a structured implementation plan before writi
 - Separate write use cases from read use cases
 - Explicitly state assumptions for unclear requirements
 
+## Non-Goals
+
+- choosing concrete class/file names for implementation
+- writing production code or tests
+- finalizing low-level schema or API payload details unless required by the brief
+
 ## Output Format
 
 - Requirements
@@ -35,8 +63,15 @@ Turn a short assignment brief into a structured implementation plan before writi
 - Performance risks
 - Test plan
 
-## Done Criteria
+## Exit Criteria
 
-- Clear implementation plan exists
-- Core domain is identified
-- Performance and edge cases are considered
+- requirements are concrete enough that implementation can start without reopening product questions
+- assumptions are explicit rather than hidden in the plan
+- domain, API, persistence, performance, and test sections are all present
+- the implementer does not need to make first-order design decisions before coding
+
+## Handoff
+
+- `spring-architecture` can choose structure from the plan
+- `domain-modeling` can begin with named concepts and rules
+- `api-delivery`, `persistence-and-indexing`, and `test-and-verify` can execute without rediscovering scope

--- a/.codex/skills/test-and-verify/SKILL.md
+++ b/.codex/skills/test-and-verify/SKILL.md
@@ -9,6 +9,26 @@ description: Use when validating business logic, persistence, and API behavior w
 
 Verify correctness and prevent regression with minimal but effective tests.
 
+## Use When
+
+- core business logic has been implemented
+- query behavior or persistence correctness must be confirmed
+- API behavior needs focused regression coverage
+
+## Inputs
+
+- implemented use cases or target code paths
+- expected success/failure scenarios
+- existing test structure and conventions
+- known risks from planning or architecture review
+
+## Deliverables
+
+- targeted tests covering core business behavior
+- failure-case tests for invalid input or invalid state
+- persistence/query verification where behavior depends on storage
+- clear pass/fail evidence for the intended acceptance scenarios
+
 ## Test Scope
 
 1. Domain / Service tests
@@ -30,15 +50,26 @@ Verify correctness and prevent regression with minimal but effective tests.
 - Cover failure cases, not only success
 - Prefer domain-level testing for rules
 
+## Non-Goals
+
+- maximizing test count for its own sake
+- covering framework boilerplate with low-value tests
+- replacing architecture or design review with tests alone
+
 ## Execution Strategy
 
 1. Run smallest test first
 2. Expand only if needed
 3. Verify persistence behavior
 
-## Done Criteria
+## Exit Criteria
 
-- Core logic is tested
-- Edge cases are covered
-- Query behavior validated
+- each critical use case has at least one success path and one meaningful failure path covered
+- business rules are validated at the lowest sensible layer
+- persistence-sensitive behavior is tested where mocking would hide risk
+- the implementer does not need to guess which scenarios are considered "enough" to ship
 
+## Handoff
+
+- `submission-readme-and-review` can summarize coverage and residual risks
+- final reviewers can see explicit evidence for correctness, not just implementation intent


### PR DESCRIPTION
## 요약

  `.codex/skills` 문서를 전반적으로 정리해
  각 skill의 사용 시점, 입력, 산출물, 비목표, 종료 기준, handoff를 명확히 했습니다.

  ## 주요 변경

  - `api-delivery`
  - `assignment-guardrails`
  - `domain-modeling`
  - `persistence-and-indexing`
  - `query-and-performance`
  - `spring-architecture`
  - `submission-readme-and-review`
  - `task-read-and-plan`
  - `test-and-verify`

  위 skill들에 공통 문서 구조를 적용했습니다.

  ## 기대 효과

  - skill 사용 기준 일관성 확보
  - 역할 중복 방지
  - handoff 명확화
  - 재사용성과 유지보수성 개선