### PR TITLE
fix: Redis 정답률 캐시 저장소 복원력 강화

### DIFF
--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/ProblemRepositoryImpl.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/solving/ProblemRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.project.quiz.infrastructure.solving;
 import com.project.quiz.application.solving.repository.ProblemRepository;
 import com.project.quiz.domain.problem.Problem;
 import com.project.quiz.infrastructure.persistence.entity.ProblemChoiceJpaEntity;
+import com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity;
 import com.project.quiz.infrastructure.persistence.mapper.ProblemMapper;
 import com.project.quiz.infrastructure.persistence.repository.ProblemAnswerKeyJpaRepository;
 import com.project.quiz.infrastructure.persistence.repository.ProblemChoiceJpaRepository;
@@ -33,11 +34,11 @@ public class ProblemRepositoryImpl implements ProblemRepository {
 
     @Override
     public List<Problem> findAllByChapterId(Long chapterId) {
-        List<com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity> problems =
+        List<ProblemJpaEntity> problems =
                 problemJpaRepository.findAllByChapterIdOrderByIdAsc(chapterId);
 
         List<Long> problemIds = problems.stream()
-                .map(com.project.quiz.infrastructure.persistence.entity.ProblemJpaEntity::getId)
+                .map(ProblemJpaEntity::getId)
                 .toList();
 
         Map<Long, List<ProblemChoiceJpaEntity>> choicesByProblemId = problemChoiceJpaRepository

--- a/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepository.java
+++ b/quiz-infrastructure/src/main/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepository.java
@@ -2,6 +2,7 @@ package com.project.quiz.infrastructure.statistics;
 
 import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheEntry;
 import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -10,6 +11,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 @Repository
+@Slf4j
 @RequiredArgsConstructor
 public class RedisProblemCorrectRateCacheRepository implements ProblemCorrectRateCacheRepository {
 
@@ -21,34 +23,52 @@ public class RedisProblemCorrectRateCacheRepository implements ProblemCorrectRat
 
     @Override
     public Optional<ProblemCorrectRateCacheEntry> find(Long problemId) {
+        String key = key(problemId);
+        String cachedValue = null;
         try {
-            String cachedValue = stringRedisTemplate.opsForValue().get(key(problemId));
+            cachedValue = stringRedisTemplate.opsForValue().get(key);
             if (cachedValue == null) {
+                log.debug("cache miss for correct rate. problemId={} key={}", problemId, key);
                 return Optional.empty();
             }
             if (NULL_SENTINEL.equals(cachedValue)) {
+                log.debug("cache hit with null sentinel for correct rate. problemId={} key={}", problemId, key);
                 return Optional.of(new ProblemCorrectRateCacheEntry(null));
             }
             return Optional.of(new ProblemCorrectRateCacheEntry(Integer.valueOf(cachedValue)));
-        } catch (RuntimeException ignored) {
+        } catch (NumberFormatException exception) {
+            log.warn("failed to parse cached correct rate. problemId={} key={} rawValue={}", problemId, key, cachedValue, exception);
+            return Optional.empty();
+        } catch (RuntimeException exception) {
+            log.warn("failed to read correct rate from redis. problemId={} key={}", problemId, key, exception);
             return Optional.empty();
         }
     }
 
     @Override
     public void put(Long problemId, Integer correctRate) {
+        String key = key(problemId);
         try {
             String value = correctRate == null ? NULL_SENTINEL : String.valueOf(correctRate);
-            stringRedisTemplate.opsForValue().set(key(problemId), value, TTL);
-        } catch (RuntimeException ignored) {
+            stringRedisTemplate.opsForValue().set(key, value, TTL);
+            if (correctRate == null) {
+                log.debug("stored null sentinel for correct rate. problemId={} key={} ttlSeconds={}", problemId, key, TTL.toSeconds());
+            } else {
+                log.debug("stored correct rate in redis. problemId={} key={} correctRate={} ttlSeconds={}", problemId, key, correctRate, TTL.toSeconds());
+            }
+        } catch (RuntimeException exception) {
+            log.warn("failed to write correct rate to redis. problemId={} key={} correctRate={}", problemId, key, correctRate, exception);
         }
     }
 
     @Override
     public void evict(Long problemId) {
+        String key = key(problemId);
         try {
-            stringRedisTemplate.delete(key(problemId));
-        } catch (RuntimeException ignored) {
+            stringRedisTemplate.delete(key);
+            log.debug("evicted correct rate cache. problemId={} key={}", problemId, key);
+        } catch (RuntimeException exception) {
+            log.warn("failed to evict correct rate cache. problemId={} key={}", problemId, key, exception);
         }
     }
 

--- a/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepositoryTest.java
+++ b/quiz-infrastructure/src/test/java/com/project/quiz/infrastructure/statistics/RedisProblemCorrectRateCacheRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.project.quiz.infrastructure.statistics;
+
+import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisProblemCorrectRateCacheRepositoryTest {
+
+    private static final String KEY = "problem:correct-rate:1001";
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private RedisProblemCorrectRateCacheRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new RedisProblemCorrectRateCacheRepository(stringRedisTemplate);
+        lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void returnsEmptyWhenCacheMiss() {
+        when(valueOperations.get(KEY)).thenReturn(null);
+
+        Optional<ProblemCorrectRateCacheEntry> result = repository.find(1001L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsNullEntryWhenNullSentinelHit() {
+        when(valueOperations.get(KEY)).thenReturn("NULL");
+
+        Optional<ProblemCorrectRateCacheEntry> result = repository.find(1001L);
+
+        assertThat(result).hasValue(new ProblemCorrectRateCacheEntry(null));
+    }
+
+    @Test
+    void returnsCorrectRateWhenNumericValueExists() {
+        when(valueOperations.get(KEY)).thenReturn("67");
+
+        Optional<ProblemCorrectRateCacheEntry> result = repository.find(1001L);
+
+        assertThat(result).hasValue(new ProblemCorrectRateCacheEntry(67));
+    }
+
+    @Test
+    void returnsEmptyWhenCachedValueCannotBeParsed() {
+        when(valueOperations.get(KEY)).thenReturn("abc");
+
+        Optional<ProblemCorrectRateCacheEntry> result = repository.find(1001L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyWhenRedisReadFails() {
+        when(valueOperations.get(KEY)).thenThrow(new RuntimeException("redis down"));
+
+        Optional<ProblemCorrectRateCacheEntry> result = repository.find(1001L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void storesNullSentinelWhenCorrectRateIsNull() {
+        repository.put(1001L, null);
+
+        verify(valueOperations).set(eq(KEY), eq("NULL"), any(Duration.class));
+    }
+
+    @Test
+    void storesNumericValueWhenCorrectRateExists() {
+        repository.put(1001L, 42);
+
+        verify(valueOperations).set(eq(KEY), eq("42"), any(Duration.class));
+    }
+
+    @Test
+    void swallowsRedisWriteFailure() {
+        doThrow(new RuntimeException("write fail"))
+                .when(valueOperations)
+                .set(eq(KEY), eq("42"), any(Duration.class));
+
+        repository.put(1001L, 42);
+    }
+
+    @Test
+    void evictsCacheKey() {
+        repository.evict(1001L);
+
+        verify(stringRedisTemplate).delete(KEY);
+    }
+
+    @Test
+    void swallowsRedisDeleteFailure() {
+        doThrow(new RuntimeException("delete fail"))
+                .when(stringRedisTemplate)
+                .delete(KEY);
+
+        repository.evict(1001L);
+    }
+}


### PR DESCRIPTION
## 요약

  Redis 기반 정답률 캐시 저장소의 read/write/delete 경로를 보강했습니다.
  예외를 무시하던 기존 동작에 진단 로그를 추가하고,
  파싱 불가능한 캐시 값도 안전하게 fallback 하도록 정리했습니다.

  ## 주요 변경

  - `RedisProblemCorrectRateCacheRepository`
    - read miss / null sentinel / 정상 hit 로깅
    - 숫자 파싱 실패 처리
    - Redis read/write/delete 실패 시 warn 로깅
  - `RedisProblemCorrectRateCacheRepositoryTest`
    - miss
    - null sentinel
    - numeric hit
    - parse failure
    - Redis read/write/delete failure
  - `ProblemRepositoryImpl`
    - 타입 import 표현 정리

  ## 검증

  - Redis cache repository 단위 테스트 추가
  - 캐시 장애 상황에서도 empty fallback / swallow 정책 유지 확인