### PR TITLE
[Refactor] random/detail API를 GET + query parameter로 정리

### DIFF
--- a/perf/k6/config.js
+++ b/perf/k6/config.js
@@ -25,9 +25,15 @@ export const submitUsers = new SharedArray("submitUsers", function () {
   return Array.from({ length: 200 }, (_, index) => index + 2000);
 });
 
+export function requestParams(tags = {}) {
+  return {
+    tags: { ...commonTags, ...tags },
+  };
+}
+
 export function jsonParams(tags = {}) {
   return {
     headers: { "Content-Type": "application/json" },
-    tags: { ...commonTags, ...tags },
+    ...requestParams(tags),
   };
 }

--- a/perf/k6/detail.js
+++ b/perf/k6/detail.js
@@ -1,6 +1,6 @@
 import http from "k6/http";
 import { check, sleep } from "k6";
-import { BASE_URL, commonThresholds, jsonParams } from "./config.js";
+import { BASE_URL, commonThresholds, requestParams } from "./config.js";
 
 const DETAIL_USER_ID = Number(__ENV.DETAIL_USER_ID || 1);
 const DETAIL_PROBLEM_ID = Number(__ENV.DETAIL_PROBLEM_ID || 1003);
@@ -25,16 +25,9 @@ export const options = {
 };
 
 export default function () {
-  const payload = JSON.stringify({
-    userId: DETAIL_USER_ID,
-    problemId: DETAIL_PROBLEM_ID,
-  });
+  const url = `${BASE_URL}/api/problems/detail?userId=${DETAIL_USER_ID}&problemId=${DETAIL_PROBLEM_ID}`;
 
-  const response = http.post(
-    `${BASE_URL}/api/problems/detail`,
-    payload,
-    jsonParams({ endpoint: "detail", scenario: "detail_read" }),
-  );
+  const response = http.get(url, requestParams({ endpoint: "detail", scenario: "detail_read" }));
 
   check(response, {
     "detail status is 200": (r) => r.status === 200,

--- a/perf/k6/mixed.js
+++ b/perf/k6/mixed.js
@@ -1,6 +1,6 @@
 import http from "k6/http";
 import { check, sleep } from "k6";
-import { BASE_URL, chapters, commonThresholds, jsonParams, randomUsers, submitUsers } from "./config.js";
+import { BASE_URL, chapters, commonThresholds, jsonParams, randomUsers, requestParams, submitUsers } from "./config.js";
 
 const HOT_PROBLEM_ID = Number(__ENV.HOT_PROBLEM_ID || 1002);
 const DETAIL_USER_ID = Number(__ENV.DETAIL_USER_ID || 1);
@@ -59,11 +59,8 @@ export const options = {
 
 export function randomScenario() {
   const userId = randomUsers[(__VU + __ITER) % randomUsers.length];
-  const response = http.post(
-    `${BASE_URL}/api/problems/random`,
-    JSON.stringify({ chapterId: chapters[0], userId }),
-    jsonParams({ endpoint: "random", scenario: "mixed_load" }),
-  );
+  const url = `${BASE_URL}/api/problems/random?chapterId=${chapters[0]}&userId=${userId}`;
+  const response = http.get(url, requestParams({ endpoint: "random", scenario: "mixed_load" }));
 
   check(response, {
     "mixed random status is 200 or 409": (r) => r.status === 200 || r.status === 409,
@@ -72,11 +69,8 @@ export function randomScenario() {
 }
 
 export function detailScenario() {
-  const response = http.post(
-    `${BASE_URL}/api/problems/detail`,
-    JSON.stringify({ userId: DETAIL_USER_ID, problemId: DETAIL_PROBLEM_ID }),
-    jsonParams({ endpoint: "detail", scenario: "mixed_load" }),
-  );
+  const url = `${BASE_URL}/api/problems/detail?userId=${DETAIL_USER_ID}&problemId=${DETAIL_PROBLEM_ID}`;
+  const response = http.get(url, requestParams({ endpoint: "detail", scenario: "mixed_load" }));
 
   check(response, {
     "mixed detail status is 200": (r) => r.status === 200,

--- a/perf/k6/random.js
+++ b/perf/k6/random.js
@@ -1,6 +1,6 @@
 import http from "k6/http";
 import { check, sleep } from "k6";
-import { BASE_URL, chapters, commonThresholds, jsonParams, randomUsers } from "./config.js";
+import { BASE_URL, chapters, commonThresholds, randomUsers, requestParams } from "./config.js";
 
 export const options = {
   scenarios: {
@@ -23,16 +23,9 @@ export const options = {
 
 export default function () {
   const userId = randomUsers[(__VU + __ITER) % randomUsers.length];
-  const payload = JSON.stringify({
-    chapterId: chapters[0],
-    userId,
-  });
+  const url = `${BASE_URL}/api/problems/random?chapterId=${chapters[0]}&userId=${userId}`;
 
-  const response = http.post(
-    `${BASE_URL}/api/problems/random`,
-    payload,
-    jsonParams({ endpoint: "random", scenario: "random_read" }),
-  );
+  const response = http.get(url, requestParams({ endpoint: "random", scenario: "random_read" }));
 
   check(response, {
     "random status is 200 or 409": (r) => r.status === 200 || r.status === 409,

--- a/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/common/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import com.project.quiz.application.solving.exception.SolvedProblemNotFoundExcep
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -56,6 +57,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<Void>> handleValidation(MethodArgumentNotValidException exception) {
+        String message = exception.getBindingResult().getFieldErrors().stream()
+                .map(this::formatFieldError)
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest()
+                .body(CommonResponse.failure("INVALID_REQUEST", message));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<CommonResponse<Void>> handleBindException(BindException exception) {
         String message = exception.getBindingResult().getFieldErrors().stream()
                 .map(this::formatFieldError)
                 .collect(Collectors.joining(", "));

--- a/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
+++ b/quiz-api/src/main/java/com/project/quiz/api/problem/ProblemController.java
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -64,8 +66,8 @@ public class ProblemController {
                     content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
-    @PostMapping("/random")
-    public ResponseEntity<CommonResponse<GetRandomProblemResponse>> getRandomProblem(@Valid @RequestBody GetRandomProblemRequest request) {
+    @GetMapping("/random")
+    public ResponseEntity<CommonResponse<GetRandomProblemResponse>> getRandomProblem(@Valid @ModelAttribute GetRandomProblemRequest request) {
         GetRandomProblemResult result = getRandomProblemService.getRandomProblem(
                 new GetRandomProblemCommand(request.userId(), request.chapterId())
         );
@@ -124,8 +126,8 @@ public class ProblemController {
                     content = @Content(schema = @Schema(implementation = CommonErrorResponse.class))
             )
     })
-    @PostMapping("/detail")
-    public ResponseEntity<CommonResponse<GetSolvedProblemDetailResponse>> getSolvedProblemDetail(@Valid @RequestBody GetSolvedProblemDetailRequest request) {
+    @GetMapping("/detail")
+    public ResponseEntity<CommonResponse<GetSolvedProblemDetailResponse>> getSolvedProblemDetail(@Valid @ModelAttribute GetSolvedProblemDetailRequest request) {
         GetSolvedProblemDetailResult result = getSolvedProblemDetailService.getDetail(
                 new GetSolvedProblemDetailCommand(request.userId(), request.problemId())
         );

--- a/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
+++ b/quiz-api/src/test/java/com/project/quiz/api/problem/ProblemControllerTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -78,9 +79,9 @@ class ProblemControllerTest {
 
         when(getRandomProblemService.getRandomProblem(any())).thenReturn(result);
 
-        mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+        mockMvc.perform(get("/api/problems/random")
+                        .queryParam("chapterId", "1")
+                        .queryParam("userId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.problemId").value(1))
@@ -95,9 +96,8 @@ class ProblemControllerTest {
     @Test
     @DisplayName("랜덤 문제 요청 검증 실패면 400을 반환한다")
     void returnBadRequestWhenRandomRequestInvalid() throws Exception {
-        mockMvc.perform(post("/api/problems/random")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(null, 1L))))
+        mockMvc.perform(get("/api/problems/random")
+                .queryParam("userId", "1"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.data").isEmpty())
@@ -110,9 +110,9 @@ class ProblemControllerTest {
         when(getRandomProblemService.getRandomProblem(any()))
                 .thenThrow(new ChapterNotFoundException(999L));
 
-        mockMvc.perform(post("/api/problems/random")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 999L))))
+        mockMvc.perform(get("/api/problems/random")
+                .queryParam("chapterId", "1")
+                .queryParam("userId", "999"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("CHAPTER_NOT_FOUND"));
@@ -124,9 +124,9 @@ class ProblemControllerTest {
         when(getRandomProblemService.getRandomProblem(any()))
                 .thenThrow(new NoAvailableProblemException(1L, 1L));
 
-        mockMvc.perform(post("/api/problems/random")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+        mockMvc.perform(get("/api/problems/random")
+                .queryParam("chapterId", "1")
+                .queryParam("userId", "1"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("NO_AVAILABLE_PROBLEM"));
@@ -195,9 +195,9 @@ class ProblemControllerTest {
                         67
                 ));
 
-        mockMvc.perform(post("/api/problems/detail")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+        mockMvc.perform(get("/api/problems/detail")
+                .queryParam("userId", "1")
+                .queryParam("problemId", "3"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.problemId").value(3))
@@ -211,9 +211,8 @@ class ProblemControllerTest {
     @Test
     @DisplayName("풀었던 문제 상세 요청이 잘못되면 400을 반환한다")
     void returnBadRequestWhenDetailRequestInvalid() throws Exception {
-        mockMvc.perform(post("/api/problems/detail")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, null))))
+        mockMvc.perform(get("/api/problems/detail")
+                .queryParam("userId", "1"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"));
@@ -225,9 +224,9 @@ class ProblemControllerTest {
         when(getSolvedProblemDetailService.getDetail(any()))
                 .thenThrow(new SolvedProblemNotFoundException(1L, 3L));
 
-        mockMvc.perform(post("/api/problems/detail")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetSolvedProblemDetailRequest(1L, 3L))))
+        mockMvc.perform(get("/api/problems/detail")
+                .queryParam("userId", "1")
+                .queryParam("problemId", "3"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("SOLVED_PROBLEM_NOT_FOUND"));
@@ -358,9 +357,9 @@ class ProblemControllerTest {
         when(getRandomProblemService.getRandomProblem(any()))
                 .thenThrow(new RuntimeException("boom"));
 
-        mockMvc.perform(post("/api/problems/random")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(new GetRandomProblemRequest(1L, 1L))))
+        mockMvc.perform(get("/api/problems/random")
+                .queryParam("chapterId", "1")
+                .queryParam("userId", "1"))
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("INTERNAL_SERVER_ERROR"))

--- a/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
+++ b/quiz-bootstrap/src/test/java/com/project/quiz/solving/GetRandomProblemEndToEndTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -134,12 +135,9 @@ class GetRandomProblemEndToEndTest {
                 ProblemStatisticsJpaEntity.create(102L, 3L, 2L, null, LocalDateTime.now())
         );
 
-        mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of(
-                                "chapterId", 1L,
-                                "userId", 1L
-                        ))))
+        mockMvc.perform(get("/api/problems/random")
+                        .queryParam("chapterId", "1")
+                        .queryParam("userId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.problemId").value(102))
@@ -171,12 +169,9 @@ class GetRandomProblemEndToEndTest {
                 SolveAttemptJpaEntity.create(1L, 1L, 101L, AttemptStatus.SKIPPED, null, null, LocalDateTime.now().minusMinutes(1))
         ));
 
-        mockMvc.perform(post("/api/problems/random")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of(
-                                "chapterId", 1L,
-                                "userId", 1L
-                        ))))
+        mockMvc.perform(get("/api/problems/random")
+                        .queryParam("chapterId", "1")
+                        .queryParam("userId", "1"))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.code").value("NO_AVAILABLE_PROBLEM"));
@@ -293,12 +288,9 @@ class GetRandomProblemEndToEndTest {
                 ProblemStatisticsJpaEntity.create(4001L, 4L, 2L, null, LocalDateTime.now())
         );
 
-        mockMvc.perform(post("/api/problems/detail")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of(
-                                "userId", 1L,
-                                "problemId", 4001L
-                        ))))
+        mockMvc.perform(get("/api/problems/detail")
+                        .queryParam("userId", "1")
+                        .queryParam("problemId", "4001"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.problemId").value(4001))


### PR DESCRIPTION
## 요약
  조회 성격의 random/detail API를 POST에서 GET으로 변경하고,
  request body 대신 query parameter를 사용하도록 정리했습니다.
  또한 k6 read 스크립트도 동일한 방식으로 반영했습니다.

  ## 변경 사항
  - `ProblemController`의 random/detail endpoint를 GET으로 변경
  - query parameter 바인딩 기반으로 전환
  - `BindException`을 `INVALID_REQUEST`로 처리하도록 예외 핸들러 보강
  - controller / end-to-end 테스트 수정
  - k6 `random`, `detail`, `mixed`의 read path를 GET으로 변경

  ## 검증
  - `./gradlew :quiz-api:test --tests '*ProblemControllerTest'`
  - `./gradlew :quiz-bootstrap:test --tests '*GetRandomProblemEndToEndTest'`