### PR TITLE
[Refactor] ProblemCorrectRatePolicy를 Spring bean으로 관리

### DIFF
--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/config/StatisticsPolicyConfiguration.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/config/StatisticsPolicyConfiguration.java
@@ -1,0 +1,14 @@
+package com.project.quiz.application.statistics.config;
+
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StatisticsPolicyConfiguration {
+
+    @Bean
+    public ProblemCorrectRatePolicy problemCorrectRatePolicy() {
+        return new ProblemCorrectRatePolicy();
+    }
+}

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemCorrectRateService.java
@@ -17,7 +17,7 @@ public class ProblemCorrectRateService {
 
     private final ProblemCorrectRateQueryRepository problemCorrectRateQueryRepository;
     private final ProblemCorrectRateCacheRepository problemCorrectRateCacheRepository;
-    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy;
 
     public Integer getCorrectRate(Long problemId) {
         Optional<ProblemCorrectRateCacheEntry> cachedCorrectRate = problemCorrectRateCacheRepository.find(problemId);

--- a/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateService.java
+++ b/quiz-application/src/main/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateService.java
@@ -17,7 +17,7 @@ public class ProblemStatisticsUpdateService {
     private final ProblemStatisticsCommandRepository problemStatisticsCommandRepository;
     private final ProblemUserStatisticsRepository problemUserStatisticsRepository;
     private final ProblemCorrectRateCacheRepository problemCorrectRateCacheRepository;
-    private final ProblemCorrectRatePolicy problemCorrectRatePolicy = new ProblemCorrectRatePolicy();
+    private final ProblemCorrectRatePolicy problemCorrectRatePolicy;
 
     @Transactional
     public void recordSolvedProblem(Long problemId, Long userId, AnswerStatus answerStatus) {

--- a/quiz-application/src/test/java/com/project/quiz/application/statistics/service/ProblemCorrectRateServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/statistics/service/ProblemCorrectRateServiceTest.java
@@ -3,6 +3,7 @@ package com.project.quiz.application.statistics.service;
 import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheEntry;
 import com.project.quiz.application.statistics.repository.ProblemCorrectRateCacheRepository;
 import com.project.quiz.application.statistics.repository.ProblemCorrectRateQueryRepository;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
 import com.project.quiz.domain.statistics.ProblemCorrectRateSummary;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,8 @@ class ProblemCorrectRateServiceTest {
     void setUp() {
         problemCorrectRateService = new ProblemCorrectRateService(
                 problemCorrectRateQueryRepository,
-                problemCorrectRateCacheRepository
+                problemCorrectRateCacheRepository,
+                new ProblemCorrectRatePolicy()
         );
     }
 

--- a/quiz-application/src/test/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateServiceTest.java
+++ b/quiz-application/src/test/java/com/project/quiz/application/statistics/service/ProblemStatisticsUpdateServiceTest.java
@@ -4,6 +4,7 @@ import com.project.quiz.application.statistics.repository.ProblemCorrectRateCach
 import com.project.quiz.application.statistics.repository.ProblemStatisticsCommandRepository;
 import com.project.quiz.application.statistics.repository.ProblemUserStatisticsRepository;
 import com.project.quiz.domain.solving.AnswerStatus;
+import com.project.quiz.domain.statistics.ProblemCorrectRatePolicy;
 import com.project.quiz.domain.statistics.ProblemStatistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,8 @@ class ProblemStatisticsUpdateServiceTest {
         problemStatisticsUpdateService = new ProblemStatisticsUpdateService(
                 problemStatisticsCommandRepository,
                 problemUserStatisticsRepository,
-                problemCorrectRateCacheRepository
+                problemCorrectRateCacheRepository,
+                new ProblemCorrectRatePolicy()
         );
     }
 


### PR DESCRIPTION
`ProblemCorrectRatePolicy`를 서비스 내부에서 직접 생성하지 않고,
  Spring bean으로 등록해 주입받도록 변경했습니다.

  ## 변경 사항
  - statistics policy 설정 클래스 추가
  - `ProblemCorrectRateService` 생성자 주입 전환
  - `ProblemStatisticsUpdateService` 생성자 주입 전환
  - 관련 단위 테스트 생성자 인자 수정

  ## 이유
  정책 객체 생성 책임을 서비스 내부에서 분리하고,
  wiring을 더 명확하게 유지하기 위함입니다.
  도메인 모듈에는 Spring 의존을 추가하지 않았습니다.

  ## 검증
  - `./gradlew :quiz-application:compileJava`
  - 관련 statistics service 테스트 코드 생성자 인자 반영